### PR TITLE
Add revenue model overview and detail pages

### DIFF
--- a/erloesmodelle/abonnement.md
+++ b/erloesmodelle/abonnement.md
@@ -1,0 +1,35 @@
+# Erlösmodell: Abonnement (Subscription)
+
+**1. Bezeichnung:**  
+Abo-Modell / Subscription  
+
+**2. Definition / Kurzbeschreibung:**  
+Wiederkehrende Zahlungen für dauerhaften Zugang zu Produkten oder Services.  
+
+**3. Typische Einsatzbereiche:**  
+B2C (Streaming, Fitness), B2B (SaaS, Cloud), B2E (Mitarbeiter-Benefits).  
+
+**4. Zielgruppen / geeignet für:**  
+Endkund:innen, Unternehmen, Mitarbeitende.  
+
+**5. Typische Beispiele:**  
+Netflix, Spotify, Microsoft 365, Salesforce.  
+
+**6. Funktionsweise / Mechanik:**  
+Monatliche/jährliche Zahlung für Zugang.  
+
+**7. Vorteile / Nutzen:**  
+- Planbare Umsätze  
+- Kundenbindung  
+- Stetiger Cashflow  
+
+**8. Nachteile / Herausforderungen:**  
+- Kündigungsrisiko (Churn)  
+- Hoher Wettbewerbsdruck  
+
+**9. Chancen für das Unternehmen:**  
+- Langfristige Kundenbeziehung  
+- Upselling-Möglichkeiten  
+
+**10. Relevanz / Kombination:**  
+Häufig kombiniert mit Freemium oder Werbung.  

--- a/erloesmodelle/cross-selling.md
+++ b/erloesmodelle/cross-selling.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Cross-Selling & Upselling
+
+**1. Bezeichnung:**  
+Cross-Selling / Upselling  
+
+**2. Definition / Kurzbeschreibung:**  
+Zusatzprodukte oder höherwertige Varianten werden beim Kauf angeboten.  
+
+**3. Typische Einsatzbereiche:**  
+E-Commerce, SaaS, Handel.  
+
+**4. Zielgruppen / geeignet für:**  
+Endkund:innen, Unternehmen.  
+
+**5. Typische Beispiele:**  
+Amazon „Kunden kauften auch …“, SaaS-Upgrade-Pakete.  
+
+**6. Funktionsweise / Mechanik:**  
+Ergänzende oder bessere Produkte werden gezielt beworben.  
+
+**7. Vorteile / Nutzen:**  
+- Höherer Warenkorbwert  
+- Mehr Umsatz pro Kunde  
+
+**8. Nachteile / Herausforderungen:**  
+- Kann aufdringlich wirken  
+- Gefahr von Kaufabbrüchen  
+
+**9. Chancen für das Unternehmen:**  
+- Erhöhung des CLV (Customer Lifetime Value)  
+- Mehr Profit ohne neue Kund:innen  
+
+**10. Relevanz / Kombination:**  
+Kombinierbar mit Direktverkauf, Abo, Freemium.  

--- a/erloesmodelle/direktverkauf.md
+++ b/erloesmodelle/direktverkauf.md
@@ -1,0 +1,35 @@
+# Erlösmodell: Direktverkauf
+
+**1. Bezeichnung:**  
+Direktverkauf / Einmalverkauf  
+
+**2. Definition / Kurzbeschreibung:**  
+Kund:innen zahlen einmalig für ein Produkt oder eine Dienstleistung.  
+
+**3. Typische Einsatzbereiche:**  
+B2C (Einzelhandel, E-Commerce), B2B (Maschinen, Beratungsprojekte).  
+
+**4. Zielgruppen / geeignet für:**  
+Endkund:innen, Unternehmen, Behörden.  
+
+**5. Typische Beispiele:**  
+Amazon, Ikea, klassischer Einzelhandel.  
+
+**6. Funktionsweise / Mechanik:**  
+Einmalige Zahlung pro Kauf.  
+
+**7. Vorteile / Nutzen:**  
+- Einfaches Modell  
+- Klare Transaktion  
+- Keine langfristige Bindung nötig  
+
+**8. Nachteile / Herausforderungen:**  
+- Keine planbaren wiederkehrenden Umsätze  
+- Hohe Abhängigkeit von Neukundengewinnung  
+
+**9. Chancen für das Unternehmen:**  
+- Schnelle Liquidität  
+- Gut kombinierbar mit Zusatzmodellen (Cross-Selling)  
+
+**10. Relevanz / Kombination:**  
+Universell in allen Geschäftsmodellen einsetzbar.  

--- a/erloesmodelle/freemium.md
+++ b/erloesmodelle/freemium.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Freemium
+
+**1. Bezeichnung:**  
+Freemium-Modell  
+
+**2. Definition / Kurzbeschreibung:**  
+Basisversion kostenlos, Premiumfunktionen gegen Bezahlung.  
+
+**3. Typische Einsatzbereiche:**  
+SaaS, Apps, Spiele, Streaming.  
+
+**4. Zielgruppen / geeignet für:**  
+Endkund:innen, Unternehmen.  
+
+**5. Typische Beispiele:**  
+Dropbox, Spotify (Free/Premium), LinkedIn.  
+
+**6. Funktionsweise / Mechanik:**  
+Kostenlose Einstiegsversion mit Limitierungen.  
+
+**7. Vorteile / Nutzen:**  
+- Niedrige Eintrittsbarriere  
+- Viralität & Reichweite  
+
+**8. Nachteile / Herausforderungen:**  
+- Monetarisierungsquote oft gering  
+- Gefahr der Gratis-Mentalität  
+
+**9. Chancen für das Unternehmen:**  
+- Schnelles Wachstum  
+- Upgrade-Potenzial  
+
+**10. Relevanz / Kombination:**  
+Oft gekoppelt mit Abo oder Werbung.  

--- a/erloesmodelle/lizenz.md
+++ b/erloesmodelle/lizenz.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Lizenzmodell
+
+**1. Bezeichnung:**  
+Lizenzmodell  
+
+**2. Definition / Kurzbeschreibung:**  
+Kund:innen erwerben Nutzungsrechte an Software, Marken oder Inhalten.  
+
+**3. Typische Einsatzbereiche:**  
+Software, Medien, Markenrechte.  
+
+**4. Zielgruppen / geeignet für:**  
+Unternehmen, Endkund:innen.  
+
+**5. Typische Beispiele:**  
+Microsoft Office (klassisch), Adobe (früher), Marken-Franchise.  
+
+**6. Funktionsweise / Mechanik:**  
+Einmalige oder wiederkehrende Lizenzgebühr.  
+
+**7. Vorteile / Nutzen:**  
+- Klare Regeln  
+- Rechtssicherheit  
+
+**8. Nachteile / Herausforderungen:**  
+- Umstellung zu Cloud-/Abo-Modellen erschwert  
+- Piraterie-Risiko  
+
+**9. Chancen für das Unternehmen:**  
+- Langfristige Kontrolle über geistiges Eigentum  
+- Hohe Marge pro Lizenz  
+
+**10. Relevanz / Kombination:**  
+Kombinierbar mit Supportverträgen oder Abo.  

--- a/erloesmodelle/marktplatz-gebuehren.md
+++ b/erloesmodelle/marktplatz-gebuehren.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Marktplatz-Gebühren
+
+**1. Bezeichnung:**  
+Marktplatz-Gebührenmodell  
+
+**2. Definition / Kurzbeschreibung:**  
+Plattformen verlangen Gebühren für die Nutzung ihres Marktplatzes.  
+
+**3. Typische Einsatzbereiche:**  
+B2B2C, Plattformökonomie.  
+
+**4. Zielgruppen / geeignet für:**  
+Verkäufer:innen, Anbieter:innen.  
+
+**5. Typische Beispiele:**  
+Etsy, Amazon Seller Fees, App Stores.  
+
+**6. Funktionsweise / Mechanik:**  
+Gebühren für Listung, Verkauf, Service oder Premium-Zugänge.  
+
+**7. Vorteile / Nutzen:**  
+- Planbare Einnahmen  
+- Plattform skaliert mit Händlern  
+
+**8. Nachteile / Herausforderungen:**  
+- Anbieter:innen unzufrieden bei hohen Gebühren  
+- Abwanderungsrisiko  
+
+**9. Chancen für das Unternehmen:**  
+- Stetige Einnahmen  
+- Starke Marktposition möglich  
+
+**10. Relevanz / Kombination:**  
+Kombinierbar mit Provisionen und Werbung.  

--- a/erloesmodelle/pay-per-use.md
+++ b/erloesmodelle/pay-per-use.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Pay-per-Use
+
+**1. Bezeichnung:**  
+Nutzungsabhängiges Modell  
+
+**2. Definition / Kurzbeschreibung:**  
+Kund:innen zahlen nur für tatsächliche Nutzung.  
+
+**3. Typische Einsatzbereiche:**  
+Cloud, Mobilität, Maschinen, Energie.  
+
+**4. Zielgruppen / geeignet für:**  
+Unternehmen, Endkund:innen.  
+
+**5. Typische Beispiele:**  
+AWS (Cloud), Carsharing, Stromtarife.  
+
+**6. Funktionsweise / Mechanik:**  
+Abrechnung nach Verbrauchseinheiten (Zeit, Daten, Stückzahl).  
+
+**7. Vorteile / Nutzen:**  
+- Flexible Kosten  
+- Fair für Kund:innen  
+
+**8. Nachteile / Herausforderungen:**  
+- Schwankende Einnahmen  
+- Hohe Abhängigkeit von Nutzung  
+
+**9. Chancen für das Unternehmen:**  
+- Marktdurchdringung  
+- Anpassung an Kundennutzung  
+
+**10. Relevanz / Kombination:**  
+Kombinierbar mit Abo oder Direktverkauf.  

--- a/erloesmodelle/provision.md
+++ b/erloesmodelle/provision.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Provision
+
+**1. Bezeichnung:**  
+Provisionsmodell  
+
+**2. Definition / Kurzbeschreibung:**  
+Unternehmen verdienen an vermittelten Verkäufen oder Transaktionen.  
+
+**3. Typische Einsatzbereiche:**  
+Marktplätze, Affiliate-Programme, Plattformen.  
+
+**4. Zielgruppen / geeignet für:**  
+Unternehmen, Endkund:innen, Plattform-User.  
+
+**5. Typische Beispiele:**  
+Booking.com, eBay, Affiliate Marketing.  
+
+**6. Funktionsweise / Mechanik:**  
+Provision auf Umsatz oder Transaktion.  
+
+**7. Vorteile / Nutzen:**  
+- Risikoarm für Kund:innen  
+- Umsatzbeteiligung ohne eigene Produktion  
+
+**8. Nachteile / Herausforderungen:**  
+- Abhängigkeit von Dritten  
+- Margen schwanken stark  
+
+**9. Chancen für das Unternehmen:**  
+- Skalierbare Einnahmen  
+- Netzwerk-Effekte  
+
+**10. Relevanz / Kombination:**  
+Häufig bei Plattform- und Marktplatzmodellen.  

--- a/erloesmodelle/uebersicht.md
+++ b/erloesmodelle/uebersicht.md
@@ -1,0 +1,25 @@
+# Erlösmodelle – Übersicht
+
+Dieses Verzeichnis enthält Steckbriefe zu den wichtigsten Erlösmodellen in digitalen und klassischen Geschäftsmodellen.  
+Jeder Steckbrief beschreibt Definition, Funktionsweise, Vorteile, Risiken und Einsatzbereiche.
+
+## Übersicht der Erlösmodelle
+
+- [Direktverkauf](direktverkauf.md)
+- [Abonnement / Subscription](abonnement.md)
+- [Freemium](freemium.md)
+- [Provision](provision.md)
+- [Werbung](werbung.md)
+- [Lizenzmodell](lizenz.md)
+- [Pay-per-Use](pay-per-use.md)
+- [Marktplatz-Gebühren](marktplatz-gebuehren.md)
+- [Cross-Selling & Upselling](cross-selling.md)
+
+## Nutzung
+Erlösmodelle sind die monetäre Ebene: Sie beantworten die Frage **„Wie verdient das Unternehmen Geld?“**  
+Sie lassen sich mit:
+- **Geschäftsmodellen** (B2C, B2B, …)  
+- **Zielgruppen** (Endkund:innen, Unternehmen, Behörden …)  
+- **Vertriebswegen** (Onlineshop, Plattform, Ausschreibung …)  
+
+frei kombinieren.

--- a/erloesmodelle/werbung.md
+++ b/erloesmodelle/werbung.md
@@ -1,0 +1,34 @@
+# Erlösmodell: Werbung
+
+**1. Bezeichnung:**  
+Werbemodell  
+
+**2. Definition / Kurzbeschreibung:**  
+Umsatz durch das Einblenden oder Verkaufen von Werbeplätzen.  
+
+**3. Typische Einsatzbereiche:**  
+Medien, Apps, Social Media, Freemium-Modelle.  
+
+**4. Zielgruppen / geeignet für:**  
+Unternehmen (als Werbetreibende), Endkund:innen (als Zielgruppe).  
+
+**5. Typische Beispiele:**  
+Google Ads, Facebook Ads, YouTube.  
+
+**6. Funktionsweise / Mechanik:**  
+Werbung wird nach Reichweite oder Klicks abgerechnet.  
+
+**7. Vorteile / Nutzen:**  
+- Kostenloser Zugang für Nutzer:innen  
+- Skalierbar mit Reichweite  
+
+**8. Nachteile / Herausforderungen:**  
+- Abhängigkeit von Werbeeinnahmen  
+- Ad-Blocker & User-Akzeptanz  
+
+**9. Chancen für das Unternehmen:**  
+- Enormes Umsatzpotenzial bei Reichweite  
+- Datenbasiertes Targeting  
+
+**10. Relevanz / Kombination:**  
+Kombinierbar mit Freemium, Content, Plattformen.  


### PR DESCRIPTION
## Summary
- add a new `erloesmodelle` directory with an overview of key revenue models
- provide detailed Steckbriefe for nine specific revenue model types

## Testing
- not run