### PR TITLE
Add cross-reference sections across business reference docs

### DIFF
--- a/business-models/b2b.md
+++ b/business-models/b2b.md
@@ -31,3 +31,10 @@ Lizenzmodelle, Abos, Projektgeschäft, Serviceverträge
 
 **10. Relevanz / Einsatzbereich:**  
 IT, SaaS, Industrie, Beratungs- und Serviceunternehmen  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md)
+- **Vertriebswege:** [Direktvertrieb](../vertriebswege/direktvertrieb.md), [Partnernetzwerke](../vertriebswege/partnernetzwerke.md), [Marktplatz / Plattform](../vertriebswege/marktplatz.md)
+- **Erlösmodelle:** [Lizenzmodell](../erloesmodelle/lizenz.md), [Pay-per-Use](../erloesmodelle/pay-per-use.md), [Abonnement](../erloesmodelle/abonnement.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)

--- a/business-models/b2b2c.md
+++ b/business-models/b2b2c.md
@@ -31,3 +31,10 @@ Provisionen, Abos, Gebühren
 
 **10. Relevanz / Einsatzbereich:**  
 E-Commerce, Plattformen, SaaS  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md), [Endkund:innen](../zielgruppen/endkundinnen.md)
+- **Vertriebswege:** [Partnernetzwerke](../vertriebswege/partnernetzwerke.md), [Marktplatz / Plattform](../vertriebswege/marktplatz.md)
+- **Erlösmodelle:** [Provision](../erloesmodelle/provision.md), [Marktplatz-Gebühren](../erloesmodelle/marktplatz-gebuehren.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)

--- a/business-models/b2c.md
+++ b/business-models/b2c.md
@@ -32,3 +32,10 @@ Direktverkauf, Abonnements, Werbung
 
 **10. Relevanz / Einsatzbereich:**  
 Handel, Konsumgüter, Lifestyle, digitale Produkte  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md)
+- **Vertriebswege:** [Onlineshop](../vertriebswege/onlineshop.md), [Social Commerce](../vertriebswege/social-commerce.md), [Mobile Apps](../vertriebswege/mobile-apps.md), [Stationärer Handel](../vertriebswege/stationaer.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Abonnement](../erloesmodelle/abonnement.md), [Werbung](../erloesmodelle/werbung.md), [Cross-Selling & Upselling](../erloesmodelle/cross-selling.md)

--- a/business-models/b2e.md
+++ b/business-models/b2e.md
@@ -31,3 +31,10 @@ Interne Kostenverrechnung, Subvention, Zusatzleistungen
 
 **10. Relevanz / Einsatzbereich:**  
 Großunternehmen, Konzerne, Organisationen mit vielen Mitarbeitenden  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Mitarbeitende](../zielgruppen/mitarbeitende.md)
+- **Vertriebswege:** [Mobile Apps](../vertriebswege/mobile-apps.md), Intranet/HR (intern), [Direktvertrieb](../vertriebswege/direktvertrieb.md)
+- **Erlösmodelle:** [Abonnement](../erloesmodelle/abonnement.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)

--- a/business-models/b2g.md
+++ b/business-models/b2g.md
@@ -32,3 +32,10 @@ Projektgeschäft, Wartungsverträge, Lizenzmodelle
 
 **10. Relevanz / Einsatzbereich:**  
 Öffentliche Verwaltung, Infrastruktur, Sicherheit, Bildung, Gesundheit  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Behörden & staatliche Institutionen](../zielgruppen/behoerden.md)
+- **Vertriebswege:** [Ausschreibungsportale](../vertriebswege/ausschreibungsportale.md), [Direktvertrieb](../vertriebswege/direktvertrieb.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Lizenzmodell](../erloesmodelle/lizenz.md), [Pay-per-Use](../erloesmodelle/pay-per-use.md)

--- a/business-models/c2b.md
+++ b/business-models/c2b.md
@@ -31,3 +31,10 @@ Provision, Honorar, Lizenzierung
 
 **10. Relevanz / Einsatzbereich:**  
 Freelancing, Kreativwirtschaft, Plattformökonomie  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md), [Plattform-User:innen](../zielgruppen/plattform-user.md)
+- **Vertriebswege:** [Marktplatz / Plattform](../vertriebswege/marktplatz.md), [Direktvertrieb](../vertriebswege/direktvertrieb.md)
+- **Erlösmodelle:** [Provision](../erloesmodelle/provision.md), [Lizenzmodell](../erloesmodelle/lizenz.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)

--- a/business-models/c2c.md
+++ b/business-models/c2c.md
@@ -31,3 +31,10 @@ Provisionen, Gebühren, Werbung
 
 **10. Relevanz / Einsatzbereich:**  
 Second-Hand-Markt, Sharing Economy, Dienstleistungen  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Plattform-User:innen](../zielgruppen/plattform-user.md)
+- **Vertriebswege:** [Marktplatz / Plattform](../vertriebswege/marktplatz.md), [Mobile Apps](../vertriebswege/mobile-apps.md), [P2P: Plattform-Mechanik](../vertriebswege/marktplatz.md)
+- **Erlösmodelle:** [Provision](../erloesmodelle/provision.md), [Marktplatz-Gebühren](../erloesmodelle/marktplatz-gebuehren.md), [Werbung](../erloesmodelle/werbung.md)

--- a/business-models/d2c.md
+++ b/business-models/d2c.md
@@ -31,3 +31,10 @@ Direktverkauf, Abo-Modelle, Bundles
 
 **10. Relevanz / Einsatzbereich:**  
 Lifestyle, Konsumgüter, E-Commerce  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md)
+- **Vertriebswege:** [Onlineshop](../vertriebswege/onlineshop.md), [Social Commerce](../vertriebswege/social-commerce.md), [Stationärer Handel](../vertriebswege/stationaer.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Abonnement](../erloesmodelle/abonnement.md), [Cross-Selling & Upselling](../erloesmodelle/cross-selling.md)

--- a/business-models/g2b.md
+++ b/business-models/g2b.md
@@ -31,3 +31,10 @@ Gebühren, staatliche Finanzierung
 
 **10. Relevanz / Einsatzbereich:**  
 E-Government, Verwaltung, Vergabeverfahren  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md)
+- **Vertriebswege:** [Ausschreibungsportale](../vertriebswege/ausschreibungsportale.md)
+- **Erlösmodelle:** [Direktverkauf (Serviceentgelte/Gebühren)](../erloesmodelle/direktverkauf.md), [Lizenzmodell](../erloesmodelle/lizenz.md)

--- a/business-models/g2c.md
+++ b/business-models/g2c.md
@@ -31,3 +31,10 @@ Gebühren, Steuern, staatliche Finanzierung
 
 **10. Relevanz / Einsatzbereich:**  
 E-Government, Verwaltung, öffentliche Services  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Bürger:innen](../zielgruppen/buergerinnen.md)
+- **Vertriebswege:** [Mobile Apps](../vertriebswege/mobile-apps.md), [Direktvertrieb](../vertriebswege/direktvertrieb.md)
+- **Erlösmodelle:** [Direktverkauf (Gebühren)](../erloesmodelle/direktverkauf.md)

--- a/business-models/p2p.md
+++ b/business-models/p2p.md
@@ -31,3 +31,10 @@ Provisionen, Gebühren, Werbung
 
 **10. Relevanz / Einsatzbereich:**  
 Sharing Economy, FinTech, Mobilität, Wohnen  
+
+---
+
+## Verknüpfungen
+- **Zielgruppen:** [Plattform-User:innen](../zielgruppen/plattform-user.md), [Endkund:innen](../zielgruppen/endkundinnen.md)
+- **Vertriebswege:** [Marktplatz / Plattform](../vertriebswege/marktplatz.md), [Mobile Apps](../vertriebswege/mobile-apps.md)
+- **Erlösmodelle:** [Provision](../erloesmodelle/provision.md), [Marktplatz-Gebühren](../erloesmodelle/marktplatz-gebuehren.md), [Werbung](../erloesmodelle/werbung.md)

--- a/erloesmodelle/abonnement.md
+++ b/erloesmodelle/abonnement.md
@@ -33,3 +33,10 @@ Monatliche/jährliche Zahlung für Zugang.
 
 **10. Relevanz / Kombination:**  
 Häufig kombiniert mit Freemium oder Werbung.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../business-models/b2b.md), [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md), [B2E](../business-models/b2e.md)
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md), [Endkund:innen](../zielgruppen/endkundinnen.md), [Mitarbeitende](../zielgruppen/mitarbeitende.md)
+- **Vertriebswege:** [Onlineshop](../vertriebswege/onlineshop.md), [Mobile Apps](../vertriebswege/mobile-apps.md), [Direktvertrieb](../vertriebswege/direktvertrieb.md)

--- a/erloesmodelle/cross-selling.md
+++ b/erloesmodelle/cross-selling.md
@@ -32,3 +32,10 @@ Ergänzende oder bessere Produkte werden gezielt beworben.
 
 **10. Relevanz / Kombination:**  
 Kombinierbar mit Direktverkauf, Abo, Freemium.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md), [B2B](../business-models/b2b.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Unternehmen](../zielgruppen/unternehmen.md)
+- **Vertriebswege:** [Onlineshop](../vertriebswege/onlineshop.md), [Stationär](../vertriebswege/stationaer.md), [Social Commerce](../vertriebswege/social-commerce.md)

--- a/erloesmodelle/direktverkauf.md
+++ b/erloesmodelle/direktverkauf.md
@@ -33,3 +33,10 @@ Einmalige Zahlung pro Kauf.
 
 **10. Relevanz / Kombination:**  
 Universell in allen Geschäftsmodellen einsetzbar.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [B2B](../business-models/b2b.md), [D2C](../business-models/d2c.md), [B2G](../business-models/b2g.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Unternehmen](../zielgruppen/unternehmen.md), [Behörden](../zielgruppen/behoerden.md)
+- **Vertriebswege:** [Onlineshop](../vertriebswege/onlineshop.md), [Direktvertrieb](../vertriebswege/direktvertrieb.md), [Stationär](../vertriebswege/stationaer.md), [Ausschreibungsportale](../vertriebswege/ausschreibungsportale.md)

--- a/erloesmodelle/freemium.md
+++ b/erloesmodelle/freemium.md
@@ -32,3 +32,10 @@ Kostenlose Einstiegsversion mit Limitierungen.
 
 **10. Relevanz / Kombination:**  
 Oft gekoppelt mit Abo oder Werbung.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [B2B](../business-models/b2b.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Unternehmen](../zielgruppen/unternehmen.md)
+- **Vertriebswege:** [Mobile Apps](../vertriebswege/mobile-apps.md), [Onlineshop](../vertriebswege/onlineshop.md)

--- a/erloesmodelle/lizenz.md
+++ b/erloesmodelle/lizenz.md
@@ -32,3 +32,10 @@ Einmalige oder wiederkehrende Lizenzgebühr.
 
 **10. Relevanz / Kombination:**  
 Kombinierbar mit Supportverträgen oder Abo.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../business-models/b2b.md), [B2G](../business-models/b2g.md)
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md), [Behörden](../zielgruppen/behoerden.md)
+- **Vertriebswege:** [Direktvertrieb](../vertriebswege/direktvertrieb.md), [Partnernetzwerke](../vertriebswege/partnernetzwerke.md), [Ausschreibungsportale](../vertriebswege/ausschreibungsportale.md)

--- a/erloesmodelle/marktplatz-gebuehren.md
+++ b/erloesmodelle/marktplatz-gebuehren.md
@@ -32,3 +32,10 @@ Gebühren für Listung, Verkauf, Service oder Premium-Zugänge.
 
 **10. Relevanz / Kombination:**  
 Kombinierbar mit Provisionen und Werbung.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B2C](../business-models/b2b2c.md), [C2C](../business-models/c2c.md), [P2P](../business-models/p2p.md)
+- **Zielgruppen:** [Plattform-User:innen](../zielgruppen/plattform-user.md), [Endkund:innen](../zielgruppen/endkundinnen.md), [Unternehmen](../zielgruppen/unternehmen.md)
+- **Vertriebswege:** [Marktplatz / Plattform](../vertriebswege/marktplatz.md)

--- a/erloesmodelle/pay-per-use.md
+++ b/erloesmodelle/pay-per-use.md
@@ -32,3 +32,10 @@ Abrechnung nach Verbrauchseinheiten (Zeit, Daten, Stückzahl).
 
 **10. Relevanz / Kombination:**  
 Kombinierbar mit Abo oder Direktverkauf.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../business-models/b2b.md)
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md)
+- **Vertriebswege:** [Direktvertrieb](../vertriebswege/direktvertrieb.md), [Partnernetzwerke](../vertriebswege/partnernetzwerke.md)

--- a/erloesmodelle/provision.md
+++ b/erloesmodelle/provision.md
@@ -32,3 +32,10 @@ Provision auf Umsatz oder Transaktion.
 
 **10. Relevanz / Kombination:**  
 Häufig bei Plattform- und Marktplatzmodellen.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [C2C](../business-models/c2c.md), [B2B2C](../business-models/b2b2c.md), [P2P](../business-models/p2p.md), [C2B](../business-models/c2b.md)
+- **Zielgruppen:** [Plattform-User:innen](../zielgruppen/plattform-user.md), [Unternehmen](../zielgruppen/unternehmen.md), [Endkund:innen](../zielgruppen/endkundinnen.md)
+- **Vertriebswege:** [Marktplatz / Plattform](../vertriebswege/marktplatz.md), [Mobile Apps](../vertriebswege/mobile-apps.md)

--- a/erloesmodelle/werbung.md
+++ b/erloesmodelle/werbung.md
@@ -32,3 +32,10 @@ Werbung wird nach Reichweite oder Klicks abgerechnet.
 
 **10. Relevanz / Kombination:**  
 Kombinierbar mit Freemium, Content, Plattformen.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [C2C](../business-models/c2c.md), [P2P](../business-models/p2p.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Plattform-User:innen](../zielgruppen/plattform-user.md)
+- **Vertriebswege:** [Social Commerce](../vertriebswege/social-commerce.md), [Marktplatz / Plattform](../vertriebswege/marktplatz.md), [Mobile Apps](../vertriebswege/mobile-apps.md)

--- a/vertriebswege/ausschreibungsportale.md
+++ b/vertriebswege/ausschreibungsportale.md
@@ -33,3 +33,10 @@ Projektgeschäft, Wartungsverträge, Lizenzmodelle.
 
 **10. Relevanz / Einsatzbereich:**  
 B2G, G2B.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2G](../business-models/b2g.md), [G2B](../business-models/g2b.md)
+- **Zielgruppen:** [Behörden](../zielgruppen/behoerden.md), [Unternehmen](../zielgruppen/unternehmen.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Lizenz](../erloesmodelle/lizenz.md)

--- a/vertriebswege/direktvertrieb.md
+++ b/vertriebswege/direktvertrieb.md
@@ -32,3 +32,10 @@ Direktverkauf, Abos, Serviceleistungen.
 
 **10. Relevanz / Einsatzbereich:**  
 D2C, B2B, B2E.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../business-models/b2b.md), [D2C](../business-models/d2c.md), [B2G](../business-models/b2g.md), [B2E](../business-models/b2e.md)
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md), [Endkund:innen](../zielgruppen/endkundinnen.md), [Behörden](../zielgruppen/behoerden.md), [Mitarbeitende](../zielgruppen/mitarbeitende.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Abonnement](../erloesmodelle/abonnement.md), [Lizenz](../erloesmodelle/lizenz.md)

--- a/vertriebswege/marktplatz.md
+++ b/vertriebswege/marktplatz.md
@@ -34,3 +34,10 @@ Provisionen, Gebühren, Werbung.
 
 **10. Relevanz / Einsatzbereich:**  
 B2C, C2C, B2B2C.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [C2C](../business-models/c2c.md), [B2B2C](../business-models/b2b2c.md), [P2P](../business-models/p2p.md)
+- **Zielgruppen:** [Plattform-User:innen](../zielgruppen/plattform-user.md), [Endkund:innen](../zielgruppen/endkundinnen.md), [Unternehmen](../zielgruppen/unternehmen.md)
+- **Erlösmodelle:** [Provision](../erloesmodelle/provision.md), [Marktplatz-Gebühren](../erloesmodelle/marktplatz-gebuehren.md), [Werbung](../erloesmodelle/werbung.md)

--- a/vertriebswege/mobile-apps.md
+++ b/vertriebswege/mobile-apps.md
@@ -32,3 +32,10 @@ Abos, In-App-Käufe, Werbung.
 
 **10. Relevanz / Einsatzbereich:**  
 B2C, D2C, B2E.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md), [B2E](../business-models/b2e.md), [G2C](../business-models/g2c.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Mitarbeitende](../zielgruppen/mitarbeitende.md), [Bürger:innen](../zielgruppen/buergerinnen.md)
+- **Erlösmodelle:** [Abonnement](../erloesmodelle/abonnement.md), [Freemium](../erloesmodelle/freemium.md), [Werbung](../erloesmodelle/werbung.md)

--- a/vertriebswege/onlineshop.md
+++ b/vertriebswege/onlineshop.md
@@ -34,3 +34,10 @@ Direktverkauf, Abos, Cross-Selling.
 
 **10. Relevanz / Einsatzbereich:**  
 B2C, D2C, B2B (teilweise).  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md), [B2B](../business-models/b2b.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Unternehmen](../zielgruppen/unternehmen.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Abonnement](../erloesmodelle/abonnement.md), [Cross-Selling](../erloesmodelle/cross-selling.md)

--- a/vertriebswege/partnernetzwerke.md
+++ b/vertriebswege/partnernetzwerke.md
@@ -32,3 +32,10 @@ Provision, Margenbeteiligung, Lizenzgebühren.
 
 **10. Relevanz / Einsatzbereich:**  
 B2B, B2B2C, SaaS.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../business-models/b2b.md), [B2B2C](../business-models/b2b2c.md)
+- **Zielgruppen:** [Unternehmen](../zielgruppen/unternehmen.md)
+- **Erlösmodelle:** [Lizenz](../erloesmodelle/lizenz.md), [Provision](../erloesmodelle/provision.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)

--- a/vertriebswege/social-commerce.md
+++ b/vertriebswege/social-commerce.md
@@ -32,3 +32,10 @@ Direktverkauf, Affiliate, Influencer-Kooperationen.
 
 **10. Relevanz / Einsatzbereich:**  
 B2C, D2C, C2C.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md), [C2C](../business-models/c2c.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md), [Plattform-User:innen](../zielgruppen/plattform-user.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Werbung](../erloesmodelle/werbung.md), [Cross-Selling](../erloesmodelle/cross-selling.md)

--- a/vertriebswege/stationaer.md
+++ b/vertriebswege/stationaer.md
@@ -32,3 +32,10 @@ Direktverkauf, Servicepakete.
 
 **10. Relevanz / Einsatzbereich:**  
 B2C, D2C, teilweise B2B.  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md)
+- **Zielgruppen:** [Endkund:innen](../zielgruppen/endkundinnen.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Cross-Selling](../erloesmodelle/cross-selling.md)

--- a/zielgruppen/behoerden.md
+++ b/zielgruppen/behoerden.md
@@ -37,3 +37,10 @@ Ausschreibungsportale, Vergabeverfahren, Rahmenverträge
 
 **10. Relevanz im Modell:**  
 B2G, G2B, G2C  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2G](../business-models/b2g.md), [G2B](../business-models/g2b.md), [G2C](../business-models/g2c.md)
+- **Vertriebswege:** [Ausschreibungsportale](../vertriebswege/ausschreibungsportale.md), [Direktvertrieb](../vertriebswege/direktvertrieb.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Lizenz](../erloesmodelle/lizenz.md)

--- a/zielgruppen/buergerinnen.md
+++ b/zielgruppen/buergerinnen.md
@@ -37,3 +37,10 @@ E-Government-Portale, Apps, Service-Center
 
 **10. Relevanz im Modell:**  
 G2C, C2G  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [G2C](../business-models/g2c.md)
+- **Vertriebswege:** [Mobile Apps](../vertriebswege/mobile-apps.md)
+- **Erlösmodelle:** [Direktverkauf (Gebühren)](../erloesmodelle/direktverkauf.md)

--- a/zielgruppen/endkundinnen.md
+++ b/zielgruppen/endkundinnen.md
@@ -37,3 +37,10 @@ Onlineshops, Mobile Apps, Social Media, stationärer Handel
 
 **10. Relevanz im Modell:**  
 B2C, D2C, B2B2C, C2C  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../business-models/b2c.md), [D2C](../business-models/d2c.md), [B2B2C](../business-models/b2b2c.md), [C2C](../business-models/c2c.md)
+- **Vertriebswege:** [Onlineshop](../vertriebswege/onlineshop.md), [Social Commerce](../vertriebswege/social-commerce.md), [Mobile Apps](../vertriebswege/mobile-apps.md), [Stationär](../vertriebswege/stationaer.md)
+- **Erlösmodelle:** [Direktverkauf](../erloesmodelle/direktverkauf.md), [Abonnement](../erloesmodelle/abonnement.md), [Werbung](../erloesmodelle/werbung.md), [Cross-Selling](../erloesmodelle/cross-selling.md)

--- a/zielgruppen/mitarbeitende.md
+++ b/zielgruppen/mitarbeitende.md
@@ -37,3 +37,10 @@ Intranet, HR-Software, mobile Apps
 
 **10. Relevanz im Modell:**  
 B2E  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2E](../business-models/b2e.md)
+- **Vertriebswege:** [Mobile Apps](../vertriebswege/mobile-apps.md), Intranet/HR (intern)
+- **Erlösmodelle:** [Abonnement](../erloesmodelle/abonnement.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)

--- a/zielgruppen/plattform-user.md
+++ b/zielgruppen/plattform-user.md
@@ -35,5 +35,12 @@ Marktplätze, Mobile Apps, APIs
 - Skalierung durch User-Generated Content  
 - Diversität an Angeboten  
 
-**10. Relevanz im Modell:**  
-C2C, C2B, P2P, B2B2C  
+**10. Relevanz im Modell:**
+C2C, C2B, P2P, B2B2C
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [C2C](../business-models/c2c.md), [C2B](../business-models/c2b.md), [P2P](../business-models/p2p.md), [B2B2C](../business-models/b2b2c.md)
+- **Vertriebswege:** [Marktplatz / Plattform](../vertriebswege/marktplatz.md), [Mobile Apps](../vertriebswege/mobile-apps.md)
+- **Erlösmodelle:** [Provision](../erloesmodelle/provision.md), [Marktplatz-Gebühren](../erloesmodelle/marktplatz-gebuehren.md), [Werbung](../erloesmodelle/werbung.md)

--- a/zielgruppen/unternehmen.md
+++ b/zielgruppen/unternehmen.md
@@ -37,3 +37,10 @@ Direktvertrieb, Messen, B2B-Plattformen, Partnernetzwerke
 
 **10. Relevanz im Modell:**  
 B2B, B2B2C, G2B  
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../business-models/b2b.md), [B2B2C](../business-models/b2b2c.md), [G2B](../business-models/g2b.md)
+- **Vertriebswege:** [Direktvertrieb](../vertriebswege/direktvertrieb.md), [Partnernetzwerke](../vertriebswege/partnernetzwerke.md), [Marktplatz](../vertriebswege/marktplatz.md)
+- **Erlösmodelle:** [Lizenz](../erloesmodelle/lizenz.md), [Pay-per-Use](../erloesmodelle/pay-per-use.md), [Abonnement](../erloesmodelle/abonnement.md), [Direktverkauf](../erloesmodelle/direktverkauf.md)


### PR DESCRIPTION
## Summary
- add Verknüpfungen sections to each business model page to surface related Zielgruppen, Vertriebswege, and Erlösmodelle
- add matching cross-links to Zielgruppen-, Vertriebswege-, and Erlösmodell-Seiten for consistent navigation across the knowledge base

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dd36567a188329a17b40de4aa27c7e