### PR TITLE
Add controlling documentation hub and method guides

### DIFF
--- a/controlling/methoden/ecommerce-controlling/attribution-modelling.md
+++ b/controlling/methoden/ecommerce-controlling/attribution-modelling.md
@@ -1,0 +1,54 @@
+# Methode: Attribution Modelling
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Marketing- und Vertriebskanäle fair bewerten, indem Touchpoints entlang der Customer Journey analysiert werden.  
+**Typische Einsatzfälle:** Budgetallokation, Kanalbewertung, Performance-Optimierung.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Versteht den Beitrag einzelner Kanäle zur Conversion.  
+- Unterstützt datenbasierte Budgetentscheidungen und Bid-Strategien.
+
+## 2) Daten & Inputs
+- Customer-Journey-Daten (Sessions, Kampagnen, Touchpoints).  
+- Conversion-Events (Käufe, Leads) inkl. Timestamp & Wert.  
+- Kanal-/Kampagnenkosten.
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Tracking-Setup prüfen (UTMs, IDs, Consent).  
+2. Modell wählen: Last-/First-Click, Positionsbasiert, Zeitverlauf, Data-Driven (Markov/Shapley).  
+3. Conversion-Werte pro Kanal berechnen.  
+4. Ergebnisse mit Spend verknüpfen und Maßnahmen ableiten.
+
+## 4) Formeln & Beispiele
+- **ROAS je Kanal:** `ROAS = Umsatz_attribuiert / Kosten`  
+- **Markov Removal Effect:** Differenz der Conversion-Rate bei Kanalentfernung.  
+- Beispiel: Kanal X Removal Effect = −18% → hoher Beitrag.
+
+## 5) Interpretation & Maßnahmen
+- Kanäle mit negativem ROAS optimieren oder pausieren.  
+- Attributionsergebnisse in Budgetplanung & Forecast integrieren.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Datenlücken (Tracking-Loss, Consent).  
+- Fehlende Offline-/CRM-Daten → Verzerrungen.  
+- Modelle vergleichen, um Extremwerte zu validieren.
+
+## 7) Checklisten
+**DoR:** [ ] Tracking-Plan, [ ] Kanalhierarchie, [ ] Kostendaten integriert  
+**DoD:** [ ] Attribution-Report, [ ] Handlungsempfehlungen, [ ] Review-Zyklus
+
+## 8) Verknüpfungen
+- Verwandt: [Conversion Funnel & A/B-Testing](conversion-funnel-und-ab-test.md), [Unit Economics](unit-economics-ltv-cac.md)  
+- KPIs: ROAS, CPA, Assisted Conversions  
+- Tools: GA4, MMP, BI, Python
+
+## 9) Beispiel-Output
+```text
+Methode: Attribution Modelling
+Zeitraum: Q3/2025
+Ergebnis: Data-Driven Modell → Paid Social +18% Wertbeitrag ggü. Last-Click, SEA −9%
+Maßnahmen: SEA-Brand-Budget -10% (Nina, 01.11.), Paid Social Upper Funnel +15% (Elisa, 05.11.)
+Review: Monatlich
+```

--- a/controlling/methoden/ecommerce-controlling/cohort-analysis-und-churn.md
+++ b/controlling/methoden/ecommerce-controlling/cohort-analysis-und-churn.md
@@ -1,0 +1,64 @@
+# Methode: Cohort Analysis & Churn/Retention
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Wiederkaufsverhalten und Bindung über Kohorten verstehen; Churn senken, Retention steigern.  
+**Typische Einsatzfälle:** CRM-Strategie, Loyalty-Programme, Lifecycle-Marketing, Kanalbewertung.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Zeigt, **welche Neukundenkohorten** (z. B. Monat/Kanal) gut performen.  
+- Identifiziert **Zeitpunkte & Gründe** für Abwanderung (Churn).  
+- Grundlage für **Budgetverteilung** und **Retention-Maßnahmen**.
+
+## 2) Daten & Inputs
+- Erstkauf-Datum & -Quelle (Kohortenbildung)  
+- Wiederkäufe je Periode (M1..M12), AOV, Deckungsbeitrag  
+- CRM-Events (E-Mail, Push), Status (aktiv/inaktiv)
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Kohorten nach **Erstkaufmonat × Kanal** bilden.  
+2. **Retention-Matrix** (Monat t nach Erstkauf: aktiver Anteil, DB/Kunde).  
+3. **Churn-Rate** je Periode berechnen; Segment-Treiber analysieren.  
+4. Maßnahmen testen (Onboarding, Reaktivierung, Loyalty).
+
+## 4) Formeln & Beispiele
+- **Retention(t):** `aktive Kund:innen_t / Startkohorte`  
+- **Churn(t):** `1 − Retention(t)`  
+- **Beispiel:** Start 10.000; aktiv in M3: 4.100 → Retention 41%, Churn 59%.
+
+## 5) Interpretation & Maßnahmen
+- Früher **Retention-Drop** → Onboarding/First-Purchase-Journey verbessern.  
+- Später **Retention-Drop** → Sortiment/Preis/Versand, Loyalty anpassen.  
+- **Segmentiert** lesen (Kanal, Kategorie, Region).
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Kohorten mischen (Äpfel & Birnen).  
+- CRM-Einfluss nicht getrennt ausgewertet (Confounder).  
+- Nur „Anzahl aktiv“ statt **DB-Beitrag** betrachten.
+
+## 7) Checklisten
+**DoR:** [ ] Saubere Neukunden-Definition, [ ] Quelle/Kanal konsistent, [ ] Zeitfenster fixiert  
+**DoD:** [ ] Retention-Matrix + DB, [ ] Maßnahmen + Owner, [ ] Review-Plan
+
+## 8) Verknüpfungen
+- Verwandt: [Unit Economics (LTV/CAC)](unit-economics-ltv-cac.md), [Attribution](attribution-modelling.md)  
+- KPIs: Retention(t), Churn(t), DB/Kunde(t), LTV  
+- Tools: SQL/BI, Python, CRM/ESP
+
+## 9) Beispiel-Output
+```text
+Methode: Cohort & Churn
+Zeitraum: Kohorten 01–06/2025
+Ergebnis: SEO-Kohorte 03/2025 Retention M6 = 38% (+6pp vs. Avg); Paid Social M1 = 21% (–11pp)
+Maßnahmen: Welcome-Flow Paid Social ausbauen (Elisa, 31.10.), Category-Trigger M2/M3 testen (Alex, 15.11.)
+Review: 30.11.
+```
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../../../business-models/b2c.md), [D2C](../../../business-models/d2c.md), [B2B2C](../../../business-models/b2b2c.md), [P2P](../../../business-models/p2p.md)
+- **Zielgruppen:** [Endkund:innen](../../../zielgruppen/endkundinnen.md), [Plattform-User:innen](../../../zielgruppen/plattform-user.md)
+- **Vertriebswege:** [Onlineshop](../../../vertriebswege/onlineshop.md), [Mobile Apps](../../../vertriebswege/mobile-apps.md), [Social Commerce](../../../vertriebswege/social-commerce.md), [Marktplatz / Plattform](../../../vertriebswege/marktplatz.md)
+- **Erlösmodelle:** [Abonnement](../../../erloesmodelle/abonnement.md), [Direktverkauf](../../../erloesmodelle/direktverkauf.md), [Werbung](../../../erloesmodelle/werbung.md), [Cross-Selling](../../../erloesmodelle/cross-selling.md)

--- a/controlling/methoden/ecommerce-controlling/conversion-funnel-und-ab-test.md
+++ b/controlling/methoden/ecommerce-controlling/conversion-funnel-und-ab-test.md
@@ -1,0 +1,50 @@
+# Methode: Conversion Funnel & A/B-Testing Impact
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Conversion-Lecks finden, Hypothesen testen, Impact quantifizieren.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Priorisierte Optimierungen entlang des Funnels (Landing → PDP → Cart → Checkout).
+- Messbarer Uplift statt Bauchgefühl.
+
+## 2) Daten & Inputs
+- Sitzungen/Visitors, Step-Through-Rates, CR, AOV
+- Testmetrik (z. B. CR oder Revenue/Visitor), Power/Signifikanz
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Funnel modellieren & Engpässe identifizieren.  
+2. Hypothesen + Impact / Confidence / Effort (ICE) priorisieren.  
+3. A/B-Test aufsetzen (Randomisierung, Dauer, Power).  
+4. Ergebnis bewerten & ausrollen oder verwerfen.
+
+## 4) Formeln & Beispiele
+- **Conversion Rate:** `CR = Bestellungen / Sitzungen`  
+- **Uplift:** `(CR_B − CR_A) / CR_A`
+
+## 5) Interpretation & Maßnahmen
+- Fokus auf **Hebel** (z. B. PDP Add-to-Cart Rate).  
+- Serielle Tests statt parallelem „Test-Zoo“.
+
+## 6) Grenzen & Fehler
+- Unterpowerte Tests → Scheinsignifikanz.  
+- Metrik-Drift (z. B. nur CTR statt Umsatz pro Besucher).
+
+## 7) Checklisten
+**DoR:** [ ] Funnel definiert, [ ] Hypothesen-Backlog, [ ] Testdesign geprüft  
+**DoD:** [ ] A/B-Report, [ ] Code/Design dokumentiert, [ ] Rollout-Plan
+
+## 8) Verknüpfungen
+- Verwandt: [Attribution](attribution-modelling.md), [Unit Economics](unit-economics-ltv-cac.md)  
+- KPIs: CR, AOV, RPV, Uplift  
+- Tools: GA4, Experiment-Plattform, Feature-Flags
+
+## 9) Beispiel-Output
+```text
+Methode: Funnel & A/B
+Zeitraum: 15.–30.10.2025
+Ergebnis: PDP-Uplift +7,2% CR (p<0,05), erwarteter Monatsumsatz +2,1%
+Maßnahmen: Rollout Variante B (Nina, 05.11.), Folge-Test: Trust-Badges im Checkout (Jamal, 20.11.)
+Review: 30.11.
+```

--- a/controlling/methoden/ecommerce-controlling/inventur-und-umschlag-haendler.md
+++ b/controlling/methoden/ecommerce-controlling/inventur-und-umschlag-haendler.md
@@ -1,0 +1,54 @@
+# Methode: Lager- & Inventory-Umschlag (Händler:innen)
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Bestände optimal steuern, Kapitalbindung minimieren und Lieferfähigkeit sichern.  
+**Typische Einsatzfälle:** Sortimentspflege, Saisongeschäft, Working-Capital-Optimierung, Lieferantensteuerung.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Sichtbar machen, welche Artikel Über- oder Unterbestand haben.  
+- Kapitalbindung und Abschriften reduzieren, Verfügbarkeit erhöhen.
+
+## 2) Daten & Inputs
+- Lagerbestände je SKU, Wareneinsatz/COGS, Abverkaufsmengen.  
+- Lieferzeiten, Mindestbestände, Sicherheitsbestände.  
+- Retourenquoten, Saisonkalender.
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Umschlagshäufigkeit und Days of Inventory (DOI) je SKU/Bereich berechnen.  
+2. ABC-/XYZ-Analyse kombinieren (Wert vs. Volatilität).  
+3. Über-/Unterbestände identifizieren und Maßnahmen definieren (Abverkauf, Nachbestellung, Nachdisposition).  
+4. Monitoring in S&OP-/Forecast-Prozesse integrieren.
+
+## 4) Formeln & Beispiele
+- **Inventory Turnover:** `COGS / Ø Bestand`  
+- **Days of Inventory:** `365 / Inventory Turnover`  
+- **Beispiel:** COGS 2 Mio. €, Ø Bestand 0,4 Mio. € → Turnover = 5, DOI = 73 Tage.
+
+## 5) Interpretation & Maßnahmen
+- Niedriger Turnover/hoher DOI → Abverkauf, Bundles, Preisaktionen.  
+- Hoher Turnover/niedriger DOI → Nachbestellen, Lieferanten-Agilität sichern.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Saisonale Peaks nicht berücksichtigen → Fehlentscheidungen.  
+- Fehlende Datenqualität (Inventurdifferenzen, SKU-Hierarchie).  
+- Nur Gesamtwerte statt Kategorie-/SKU-Sicht.
+
+## 7) Checklisten
+**DoR:** [ ] Bestandshistorie vollständig, [ ] Forecast aktualisiert, [ ] Lieferzeiten validiert  
+**DoD:** [ ] Maßnahmenliste je SKU-Klasse, [ ] Cash-Effekt quantifiziert, [ ] Reviewtermin fixiert
+
+## 8) Verknüpfungen
+- Verwandt: [Working-Capital-Controlling](../unternehmenscontrolling/arbeitskapital-controlling.md), [RFM & Basket Analysis](rfm-und-basket-analysis.md)  
+- KPIs: Inventory Turnover, DOI, Out-of-Stock Rate  
+- Tools: ERP/WMS, BI, Forecasting-Tools
+
+## 9) Beispiel-Output
+```text
+Methode: Inventory-Umschlag
+Zeitraum: Q3/2025
+Ergebnis: ABC-A-Artikel Turnover 9 (OK); C-Artikel DOI 180 → Abverkaufskampagne nötig
+Maßnahmen: Flash-Sale C-Artikel (Mira, 10.10.), Lieferantenvertrag A-Artikel verlängern (Tom, 30.10.)
+Review: Monatlich
+```

--- a/controlling/methoden/ecommerce-controlling/marketplace-take-rate-und-gmv.md
+++ b/controlling/methoden/ecommerce-controlling/marketplace-take-rate-und-gmv.md
@@ -1,0 +1,56 @@
+# Methode: Marketplace-Kennzahlen (GMV, Take Rate, Net Revenue)
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Performance von Marktplatz- oder Plattformmodellen steuern, Einnahmequellen optimieren und Partner:innen-Ökosystem managen.  
+**Typische Einsatzfälle:** Marktplatz-Launch, Partner-Management, Revenue-Optimierung, Investor:innen-Reporting.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Transparenz über GMV, Take Rate, Provisionen und Net Revenue.  
+- Hebel zur Monetarisierung (Fees, Services, Werbung) priorisieren.
+
+## 2) Daten & Inputs
+- Brutto-Transaktionsvolumen (GMV) je Partner/Kategorie.  
+- Kommissionsmodelle, Gebühren, Services (Fulfillment, Ads).  
+- Kostenstrukturen (Logistik, Payment, Support).
+
+## 3) Vorgehen (Schritt für Schritt)
+1. GMV und Take Rate je Segment/Partner ausweisen.  
+2. Zusätzliche Monetarisierungen (Fulfillment, Ads, SaaS) analysieren.  
+3. Net Revenue & Deckungsbeiträge je Partner berechnen.  
+4. Maßnahmen definieren (Preis-/Fee-Änderungen, Partner-Mix, Upselling).
+
+## 4) Formeln & Beispiele
+- **GMV:** `GMV = ∑ (Bestellwert inkl. Steuern/Shipping)`  
+- **Take Rate:** `Take Rate = Plattformumsatz / GMV`  
+- **Net Revenue:** `Net Revenue = Take Rate × GMV − direkte Kosten`  
+- Beispiel: GMV 10 Mio. €, Take Rate 12% → Plattformumsatz 1,2 Mio. €, Kosten 0,4 Mio. € → Net Revenue 0,8 Mio. €.
+
+## 5) Interpretation & Maßnahmen
+- Niedrige Take Rate → Monetarisierungsoptionen prüfen (Ads, Services).  
+- Negative Deckungsbeiträge → Gebührenstruktur oder Kosten prüfen.  
+- Partner-Performance mit Incentives/Enablement steuern.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Unterschiedliche GMV-Definitionen (inkl./exkl. Taxes, Returns) → Konsistenz sicherstellen.  
+- Abhängigkeit von wenigen Top-Partner:innen → Konzentrationsrisiko.  
+- Services mit indirektem Wertbeitrag (z. B. Ads) sauber zuordnen.
+
+## 7) Checklisten
+**DoR:** [ ] Partnerliste & Verträge, [ ] GMV-Definition klar, [ ] Kostenmapping bereit  
+**DoD:** [ ] GMV/Take Rate Report, [ ] Maßnahmenplan, [ ] Partner-Kommunikation abgestimmt
+
+## 8) Verknüpfungen
+- Verwandt: [Unit Economics](unit-economics-ltv-cac.md), [Attribution Modelling](attribution-modelling.md)  
+- KPIs: GMV, Take Rate, Net Revenue, Partner Retention  
+- Tools: Marketplace-Backend, BI, Finance-Tools
+
+## 9) Beispiel-Output
+```text
+Methode: Marketplace KPIs
+Zeitraum: Q3/2025
+Ergebnis: GMV 28 Mio. € (+22% YoY), Take Rate 11,5% (–0,6pp vs. Plan) → Net Revenue 3,1 Mio. €
+Maßnahmen: Neue Listing Fee testen (Mara, 15.11.), Fulfillment-Upsell bei Top-20 Partnern (Chris, 30.11.)
+Review: Monatlich
+```

--- a/controlling/methoden/ecommerce-controlling/rfm-und-basket-analysis.md
+++ b/controlling/methoden/ecommerce-controlling/rfm-und-basket-analysis.md
@@ -1,0 +1,55 @@
+# Methode: RFM- & Basket-Analysis
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Kundensegmente nach Kaufaktualität, Häufigkeit und monetärem Wert identifizieren sowie Warenkorbkombinationen verstehen.  
+**Typische Einsatzfälle:** CRM-Segmentierung, Cross-/Upselling, Kampagnen-Personalisierung.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Priorisierung von Loyalitäts- und Reaktivierungsmaßnahmen.  
+- Identifikation von Cross-Selling-Potenzialen und Bundles.
+
+## 2) Daten & Inputs
+- Transaktionsdaten (Kaufdatum, Umsatz, Produkte, Kunde).  
+- Kund:innen-Stammdaten, Produktkategorien.  
+- Optional: Kampagnenkontakte, Rabattinformationen.
+
+## 3) Vorgehen (Schritt für Schritt)
+1. RFM-Scores pro Kund:in berechnen (Recency, Frequency, Monetary).  
+2. Kundensegmente ableiten (z. B. Champions, At Risk, Hibernating).  
+3. Warenkorb-/Assoziationsanalyse (z. B. Apriori, FP-Growth) durchführen.  
+4. Maßnahmen und Kampagnen pro Segment planen.
+
+## 4) Formeln & Beispiele
+- **R-Score:** Ranking nach Tagen seit letztem Kauf (niedriger besser).  
+- **F-Score:** Ranking nach # Käufen.  
+- **M-Score:** Ranking nach Umsatz/Deckungsbeitrag.  
+- **Lift:** `Lift = Support(ItemSet) / (Support(A) × Support(B))`
+
+## 5) Interpretation & Maßnahmen
+- Champions mit Loyalitätsprogrammen halten; „At Risk“ reaktivieren.  
+- Basket-Insights nutzen für Bundles, Empfehlungen, Platzierungen.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Nur vergangenes Verhalten → neue Produkte/Preise berücksichtigen.  
+- Datenqualität (z. B. Dubletten) entscheidend für Segmenttreue.  
+- Lift-Werte kritisch prüfen (Stichprobengröße).
+
+## 7) Checklisten
+**DoR:** [ ] Transaktionsdaten bereinigt, [ ] Kund:innen-ID stabil, [ ] Produktklassifikation konsistent  
+**DoD:** [ ] Segmente dokumentiert, [ ] Maßnahmen & Owner, [ ] Kampagnenplan aktualisiert
+
+## 8) Verknüpfungen
+- Verwandt: [Unit Economics](unit-economics-ltv-cac.md), [Cohort Analysis](cohort-analysis-und-churn.md)  
+- KPIs: Average Order Value, Repeat Rate, Attach Rate  
+- Tools: SQL/BI, Python, CRM/Marketing Automation
+
+## 9) Beispiel-Output
+```text
+Methode: RFM & Basket
+Zeitraum: FY 2025
+Ergebnis: Champions-Segment 18% der Kunden → 46% Umsatz; Lift(Kaffee, Filter) = 3,1
+Maßnahmen: VIP-Programm erweitern (Sven, 15.11.), Bundle „Kaffee+Filter“ launchen (Mira, 01.12.)
+Review: Quartalsweise
+```

--- a/controlling/methoden/ecommerce-controlling/unit-economics-ltv-cac.md
+++ b/controlling/methoden/ecommerce-controlling/unit-economics-ltv-cac.md
@@ -1,0 +1,52 @@
+# Methode: Unit Economics (LTV / CAC)
+
+**Kategorie:** E-Commerce-Controlling  
+**Ziel:** Nachhaltigkeit des Wachstums bewerten (Kund:innenwert vs. Akquisekosten).
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Entscheiden, welche Kanäle/Segmente profitabel skalieren.
+- Budgetallokation & Bid-Strategie faktenbasiert steuern.
+
+## 2) Daten & Inputs
+- CAC je Kanal/Kampagne (Marketingkosten / gewonnene Neukund:innen)
+- LTV (Deckungsbeitrag über Lebenszeit; Kohortenbasiert)
+- DB je Bestellung, Retourenquoten, Payment/Versand
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Kohorten definieren (Monat/Quelle/Region).  
+2. CAC je Kohorte ermitteln.  
+3. LTV je Kohorte über Zeit (t+3/6/12) aggregieren.  
+4. **LTV/CAC** und **Payback-Periode** berechnen.
+
+## 4) Formeln & Beispiele
+- **CAC:** `CAC = Marketingkosten / #Neukund:innen`  
+- **LTV (vereinfachte Näherung):** `LTV = ∑(DB_t * Retention_t) / (1 + r)^t`  
+- **Daumenregel:** LTV/CAC ≥ 3, Payback ≤ 12 Monate (je nach Modell).
+
+## 5) Interpretation & Maßnahmen
+- LTV/CAC < 1: Kanal stoppen/umbauen; Landingpages/Onboarding optimieren.
+- Kurze Payback-Zeit = schnelleres Reinvestitionspotenzial.
+
+## 6) Grenzen & Fehler
+- Überschätzung von LTV (Optimismus, fehlende Kosten).
+- Kohorten-Mix verschiebt Durchschnitt – immer segmentiert lesen.
+
+## 7) Checklisten
+**DoR:** [ ] Kohortenlogik, [ ] saubere Neukunden-Definition, [ ] DB-Logik inkl. Retouren  
+**DoD:** [ ] LTV/CAC je Kohorte, [ ] Maßnahmen-Board, [ ] Review-Termin
+
+## 8) Verknüpfungen
+- Verwandt: [Cohort Analysis](cohort-analysis-und-churn.md), [Attribution](attribution-modelling.md)  
+- KPIs: LTV, CAC, Payback, DB je Bestellung  
+- Tools: SQL/BI, Python, GA4, Attribution-Tools
+
+## 9) Beispiel-Output
+```text
+Methode: Unit Economics (LTV/CAC)
+Zeitraum: Kohorten 01–06/2025
+Ergebnis: Meta CAC 42 €, LTV12 138 € → LTV/CAC = 3,3 (OK); TikTok LTV/CAC = 1,7 (Achtung)
+Maßnahmen: TikTok Landingpage & Creative testen (Elisa, 31.10.), E-Mail Onboarding erweitern (Alex, 15.11.)
+Review: 30.11.
+```

--- a/controlling/methoden/unternehmenscontrolling/arbeitskapital-controlling.md
+++ b/controlling/methoden/unternehmenscontrolling/arbeitskapital-controlling.md
@@ -1,0 +1,54 @@
+# Methode: Working-Capital-Controlling
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Liquidität optimieren, indem Forderungen, Verbindlichkeiten und Lagerbestände aktiv gesteuert werden.  
+**Typische Einsatzfälle:** Cash-Management, Finanzierung von Wachstum, Supply-Chain-Optimierung.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Reduziert gebundenes Kapital und verbessert den Cashflow.
+- Erhöht Verhandlungsspielraum bei Lieferant:innen und Kund:innen.
+
+## 2) Daten & Inputs
+- Offene Posten (Debitoren/Kreditoren) nach Fälligkeiten.
+- Lagerbestände, Umschlagshäufigkeit, Sicherheitsbestände.
+- Zahlungsbedingungen, Skonti, Lieferzeiten.
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Kennzahlen bestimmen: DSO, DPO, DIO sowie Cash Conversion Cycle.  
+2. Treiber analysieren (Top-Kund:innen, Lieferant:innen, SKU-Gruppen).  
+3. Maßnahmen ableiten (Payment Terms, Factoring, Bestandsoptimierung).  
+4. Wirkung monitoren und Forecast aktualisieren.
+
+## 4) Formeln & Beispiele
+- **DSO:** `DSO = Forderungen / Umsatz × 365`  
+- **DPO:** `DPO = Verbindlichkeiten / Wareneinsatz × 365`  
+- **DIO:** `DIO = Ø Bestand / Wareneinsatz × 365`  
+- **CCC:** `CCC = DSO + DIO − DPO`
+
+## 5) Interpretation & Maßnahmen
+- Kürzerer CCC → weniger Liquiditätsbedarf.  
+- Maßnahmen priorisieren nach Hebel (Forderungsmanagement vs. Einkauf vs. Lager).
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Saisonale Effekte verzerren Momentaufnahmen → Trend betrachten.  
+- Nur Kennzahlen ohne Prozessmaßnahmen → Wirkung verpufft.
+
+## 7) Checklisten
+**DoR:** [ ] Daten nach Altersstruktur, [ ] Zahlungsbedingungen bekannt, [ ] Forecast aktualisiert  
+**DoD:** [ ] Maßnahmenliste mit Owner, [ ] Effekte quantifiziert, [ ] Cash-Plan angepasst
+
+## 8) Verknüpfungen
+- Verwandt: [Investitionsrechnung (NPV/IRR/Payback)](investitionsrechnung-npv-irr.md), [Rolling Forecast](rolling-forecast.md)  
+- KPIs: Cash Conversion Cycle, Net Working Capital, Liquidity Ratio  
+- Tools: ERP, Treasury-Systeme, BI
+
+## 9) Beispiel-Output
+```text
+Methode: Working-Capital-Controlling
+Zeitraum: Q3/2025
+Ergebnis: CCC von 68 auf 54 Tage verbessert → +2,1 Mio. € Liquidität
+Maßnahmen: DSO-Taskforce (Anna, 15.10.), VMI-Pilot mit Lieferant X (Marco, 30.10.)
+Review: Monatlich
+```

--- a/controlling/methoden/unternehmenscontrolling/balanced-scorecard.md
+++ b/controlling/methoden/unternehmenscontrolling/balanced-scorecard.md
@@ -1,0 +1,66 @@
+# Methode: Balanced Scorecard (BSC)
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Strategie in messbare Ziele und Kennzahlen über vier Perspektiven übersetzen und steuern.  
+**Typische Einsatzfälle:** Strategieumsetzung, OKR-Ableitung, KPI-System, Management-Reporting.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Verknüpft **Vision/Strategie** mit **operativen Zielen**.
+- Schafft **Balance** zwischen Finanzen, Kund:innen, Prozessen, Lernen/Innovation.
+- Fördert **Ursache-Wirkungs-Denken** (Leading vs. Lagging KPIs).
+
+## 2) Daten & Inputs
+- Strategische Ziele / Leitplanken
+- Bestehende KPIs & Datenquellen (ERP/CRM/BI)
+- Verantwortlichkeiten & Zielwerte (Targets)
+
+## 3) Vorgehen (Schritt für Schritt)
+1. **Strategiekarte** erstellen (4 Perspektiven, je 3–5 Ziele).  
+2. Je Ziel **Messgröße**, **Target**, **Owner**, **Initiativen** definieren.  
+3. **Leading/Lagging** unterscheiden (früh vs. spät).  
+4. **Reporting-Rhythmus** festlegen (monatlich/Quartal).  
+5. Review: Abweichungen → Maßnahmen/OKRs aktualisieren.
+
+## 4) Formeln & Beispiele
+- Keine festen Formeln; Fokus auf **Ziel-KPI-Zuordnung**.  
+- Beispiel: „Kundenzufriedenheit steigern“ → **NPS ≥ 50**, Owner CX.
+
+## 5) Interpretation & Maßnahmen
+- Ampellogik (grün/gelb/rot) je KPI.  
+- Bei Rot: Treiberanalyse (Ursächliche Prozesse/Initiativen prüfen).
+
+## 6) Grenzen, Annahmen & typische Fehler
+- **Überfrachtung** (zu viele KPIs).  
+- **Fehlende Ownership** (niemand verantwortlich).  
+- **Kosmetik-KPIs** ohne Ursache-Wirkung.
+
+## 7) Checklisten
+**DoR:** [ ] Strategiekarte v0, [ ] Datenquellen, [ ] KPI-Definitionen  
+**DoD:** [ ] Scorecard veröffentlicht, [ ] Maßnahmen + Owner, [ ] Review-Zyklus aktiv
+
+## 8) Verknüpfungen
+- Verwandt: OKR, Strategy Map, Rolling Forecast  
+- KPIs: NPS, EBIT, On-Time Delivery, Time-to-Market  
+- Tools: BI/Looker, Notion/Confluence, OKR-Tool
+
+## 9) Beispiel-Output
+```text
+Methode: BSC
+Zeitraum: FY 2026
+Perspektiven & Ziele:
+- Finanzen: EBIT-Marge ≥ 12% (Owner: CFO)
+- Kund:innen: NPS ≥ 50 (Owner: CX Lead)
+- Prozesse: Liefertermintreue ≥ 95% (Owner: Ops)
+- Lernen: Release-Zyklus < 2 Wochen (Owner: Eng)
+Review: Quartal Q1–Q4
+```
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2C](../../../business-models/b2c.md), [B2B](../../../business-models/b2b.md), [D2C](../../../business-models/d2c.md), [B2G](../../../business-models/b2g.md)
+- **Zielgruppen:** [Endkund:innen](../../../zielgruppen/endkundinnen.md), [Unternehmen](../../../zielgruppen/unternehmen.md), [Behörden](../../../zielgruppen/behoerden.md), [Mitarbeitende](../../../zielgruppen/mitarbeitende.md)
+- **Vertriebswege:** [Onlineshop](../../../vertriebswege/onlineshop.md), [Direktvertrieb](../../../vertriebswege/direktvertrieb.md), [Marktplatz / Plattform](../../../vertriebswege/marktplatz.md), [Ausschreibungsportale](../../../vertriebswege/ausschreibungsportale.md)
+- **Erlösmodelle:** [Direktverkauf](../../../erloesmodelle/direktverkauf.md), [Abonnement](../../../erloesmodelle/abonnement.md), [Lizenz](../../../erloesmodelle/lizenz.md), [Provision](../../../erloesmodelle/provision.md)

--- a/controlling/methoden/unternehmenscontrolling/deckungsbeitrag.md
+++ b/controlling/methoden/unternehmenscontrolling/deckungsbeitrag.md
@@ -1,0 +1,57 @@
+# Methode: Deckungsbeitrag (DB I–III)
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Ermitteln, welchen Beitrag Produkte/Projekte zur Deckung fixer Kosten und zum Gewinn leisten.  
+**Typische Einsatzfälle:** Preisgestaltung, Sortimentsbereinigung, Priorisierung von Projekten.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Sichtbar machen, welche Leistungen profitabel sind – auch bei gleichem Umsatz.
+- Grundlage für **Make-or-Buy**, **Preisuntergrenzen**, **Kampagnen-Aussteuerung**.
+
+## 2) Daten & Inputs
+- Umsätze je Produkt/Projekt
+- Variable Kosten (EK, Versand, Zahlungsgebühren, variable Marketingkosten)
+- Fixkosten (für DB II/III zuordnen/verteilen)
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Variable Kosten pro Einheit konsolidieren.  
+2. DB I = Umsatz − variable Kosten.  
+3. DB II = DB I − produkt-/bereichsfixe Kosten.  
+4. DB III = DB II − unternehmensfixe Kosten (≈ Betriebsergebnis).
+
+## 4) Formeln & Beispiele
+- **DB I (Stück):** `DB1 = Preis − variable Kosten`  
+- **Beispiel:** Preis 100 €, var. Kosten 60 € → DB1 = 40 €.
+
+## 5) Interpretation & Maßnahmen
+- **DB1 > 0:** wirtschaftlich sinnvoll; optimieren (Preis, Kosten, Mix).
+- **DB1 < 0:** rausnehmen, redesignen oder Preis/Kosten neu verhandeln.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Falsche Einstufung „variabel vs. fix“.  
+- Verdeckte Kosten (z. B. Retouren, Payment-Fees) vergessen.
+
+## 7) Checklisten
+**DoR:** [ ] Daten je SKU/Projekt, [ ] Kostenmapping klar, [ ] Zeitraum fixiert  
+**DoD:** [ ] DB-Report versioniert, [ ] Maßnahmen + Owner, [ ] Review-Termin
+
+## 8) Verknüpfungen
+- Verwandt: [Prozesskostenrechnung / ABC](prozesskostenrechnung-abc.md), [Szenarioanalyse](szenario-und-sensitivitaet.md)  
+- KPIs: Bruttomarge, DB-Quote, EBIT  
+- Tools: SQL/BI, Excel
+
+## 9) Beispiel-Output (Vorlage)
+```text
+Methode: Deckungsbeitrag
+Zeitraum: Q1/2025
+Datengrundlage: ERP v2025-03, Export 2025-04-01
+Ergebnis: 18% der SKUs sind negativ profitabel → Maßnahmen fokussieren auf 42 SKUs.
+Top-Treiber:
+1) Versandkosten > Ziel
+2) Zahlungsgebühren hoch
+3) Rabattmix ungünstig
+Maßnahmen: Versandtarife neu verhandeln (Alex, 15.10.), Zahlungsanbieter B testen (Nina, 31.10.)
+Review: 30.11.
+```

--- a/controlling/methoden/unternehmenscontrolling/investitionsrechnung-npv-irr.md
+++ b/controlling/methoden/unternehmenscontrolling/investitionsrechnung-npv-irr.md
@@ -1,0 +1,65 @@
+# Methode: Investitionsrechnung (NPV / IRR / Payback)
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Wirtschaftlichkeit von Investitionen bewerten und Projekte vergleichbar machen.  
+**Typische Einsatzfälle:** Capex-Entscheidungen, Software-Build-vs-Buy, Maschinenkauf, Marketing-Großprojekte.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Bewertet **Kapitalwert** (NPV) und **Rendite** (IRR) unter Zeitwert des Geldes.
+- Vergleich von Alternativen (Projekt A vs. B) auf **Cashflow-Basis**.
+
+## 2) Daten & Inputs
+- Anfangsinvestition (Capex)  
+- Erwartete Netto-Cashflows je Periode (Einzahlungen − Auszahlungen)  
+- Diskontsatz (WACC / Mindestverzinsung)  
+- Projektlaufzeit, Restwert
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Cashflows je Periode schätzen (konservativ, Szenarien).  
+2. Diskontsatz festlegen (z. B. WACC).  
+3. **NPV** und **IRR** berechnen; **Payback** ergänzen.  
+4. Sensitivität: Preis, Menge, Kosten, Diskontsatz variieren.
+
+## 4) Formeln & Beispiele
+- **NPV:** `NPV = Σ [ CF_t / (1 + r)^t ] − I0`  
+- **IRR:** Zinssatz `r`, für den `NPV = 0`. (numerisch)  
+- **Payback:** Perioden bis kumulierter Cashflow ≥ I0.  
+- **Mini-Beispiel:** I0 = 100k; CF1..3 = 50k/40k/30k; r = 10% → NPV ≈ 6,1k → **annehmen**.
+
+## 5) Interpretation & Maßnahmen
+- **NPV > 0**: Wertbeitrag; **IRR > r**: Rendite über Hürde.  
+- Engpassressourcen auf höchste NPV/IRR priorisieren.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Cashflow-Schätzungen zu optimistisch.  
+- Diskontsatz falsch (Risiko/Inflation ignoriert).  
+- **IRR-Fallstricke** (mehrfache Vorzeichenwechsel).
+
+## 7) Checklisten
+**DoR:** [ ] Cashflow-Plan, [ ] r definiert, [ ] Szenarien (Base/Best/Worst)  
+**DoD:** [ ] NPV/IRR/Payback dokumentiert, [ ] Sensitivität anhängen, [ ] Entscheidung + Begründung
+
+## 8) Verknüpfungen
+- Verwandt: [Szenario- & Sensitivitätsanalyse](szenario-und-sensitivitaet.md), [Rolling Forecast](rolling-forecast.md)  
+- KPIs: ROI, EBIT-Effekt, Cash Conversion  
+- Tools: Excel/Python, BI
+
+## 9) Beispiel-Output
+```text
+Methode: Investitionsrechnung
+Projekt: Shop-Replatforming
+I0: 350.000 €
+Cashflows (3 Jahre): 140k / 160k / 120k
+r (WACC): 9%
+Ergebnis: NPV +51k; IRR 13,4%; Payback 2,2 Jahre → Empfehlung: Go (mit Phasen-Gates)
+```
+
+---
+
+## Verknüpfungen
+- **Geschäftsmodelle:** [B2B](../../../business-models/b2b.md), [B2C](../../../business-models/b2c.md), [D2C](../../../business-models/d2c.md), [B2G](../../../business-models/b2g.md)
+- **Zielgruppen:** [Unternehmen](../../../zielgruppen/unternehmen.md), [Endkund:innen](../../../zielgruppen/endkundinnen.md), [Behörden](../../../zielgruppen/behoerden.md)
+- **Vertriebswege:** [Onlineshop](../../../vertriebswege/onlineshop.md), [Partnernetzwerke](../../../vertriebswege/partnernetzwerke.md), [Stationär](../../../vertriebswege/stationaer.md), [Ausschreibungsportale](../../../vertriebswege/ausschreibungsportale.md)
+- **Erlösmodelle:** [Direktverkauf](../../../erloesmodelle/direktverkauf.md), [Abonnement](../../../erloesmodelle/abonnement.md), [Lizenz](../../../erloesmodelle/lizenz.md), [Pay-per-Use](../../../erloesmodelle/pay-per-use.md)

--- a/controlling/methoden/unternehmenscontrolling/prozesskostenrechnung-abc.md
+++ b/controlling/methoden/unternehmenscontrolling/prozesskostenrechnung-abc.md
@@ -1,0 +1,53 @@
+# Methode: Prozesskostenrechnung / Activity-Based Costing (ABC)
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Gemeinkosten verursachungsgerecht auf Produkte, Kunden oder Prozesse verteilen.  
+**Typische Einsatzfälle:** Produktkalkulation, Servicekalkulation, Profitabilitätsanalysen, Shared-Service-Controlling.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Transparenz über Kostenstrukturen und Kostentreiber schaffen.
+- Unprofitable Kunden-/Produktsegmente identifizieren.
+
+## 2) Daten & Inputs
+- Prozessinventar mit Aktivitäten, Ressourcen und Kostentreibern.
+- Gemeinkostenblöcke (Personal, IT, Facility etc.).
+- Leistungsgrößen je Objekt (Stückzahlen, Aufträge, Tickets).
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Prozesse und Aktivitäten modellieren; Treibergrößen festlegen.  
+2. Ressourcen- und Prozesskosten ermitteln und Treiber zuordnen.  
+3. Kosten auf Kostenträger (Produkte/Kunden) verteilen.  
+4. Ergebnisse analysieren und Maßnahmen ableiten.
+
+## 4) Formeln & Beispiele
+- **Prozesskostensatz:** `Kosten Prozess / Leistungsmenge`  
+- **Kostenzuordnung:** `Kostenobjekt = Σ (Prozesskostensatz × Inanspruchnahme)`
+
+## 5) Interpretation & Maßnahmen
+- Fokus auf hohe Kostentreiber → Prozessoptimierung oder Preisanpassung.  
+- Produktportfolio/Servicelevel anhand Profitabilität justieren.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Hoher Implementierungsaufwand.  
+- Falsche Treiberwahl führt zu verzerrten Ergebnissen.  
+- Regelmäßige Aktualisierung nötig.
+
+## 7) Checklisten
+**DoR:** [ ] Prozesslandkarte, [ ] Kostentreiber definiert, [ ] Datenbasis geprüft  
+**DoD:** [ ] Kostenmodelle dokumentiert, [ ] Maßnahmen abgestimmt, [ ] Review-Zyklus geplant
+
+## 8) Verknüpfungen
+- Verwandt: [Deckungsbeitrag](deckungsbeitrag.md), [Zero-Based Budgeting](zero-based-budgeting.md)  
+- KPIs: Prozesskostensatz, Contribution Margin by Segment  
+- Tools: BI, Process Mining, Controlling-Software
+
+## 9) Beispiel-Output
+```text
+Methode: Prozesskostenrechnung
+Zeitraum: FY 2025
+Ergebnis: Service-Level „Premium Support“ verursacht 35% höhere Prozesskosten → Preismodell anpassen
+Maßnahmen: Support-SLAs neu kalkulieren (Chris, 15.11.), Self-Service-Angebote ausbauen (Lara, 30.11.)
+Review: Halbjährlich
+```

--- a/controlling/methoden/unternehmenscontrolling/rolling-forecast.md
+++ b/controlling/methoden/unternehmenscontrolling/rolling-forecast.md
@@ -1,0 +1,50 @@
+# Methode: Rolling Forecast (monatlich/vierteljährlich)
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Dynamische, gleitende Planung statt starrer Jahresbudgets.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Früherkennung von Abweichungen; schnellere Kurskorrekturen.
+- Bessere Liquiditäts- & Kapazitätsplanung.
+
+## 2) Daten & Inputs
+- Ist-Zahlen (P&L, Cashflow, Pipeline)
+- Treiber (Preise, Volumen, Conversion, Personalkapazität)
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Forecast-Horizont festlegen (z. B. 12 Monate rolling).  
+2. Treibermodelle definieren (Preis × Menge, CAC → Umsatz etc.).  
+3. Monatlich aktualisieren (Ist einpflegen, Annahmen refreshen).  
+4. Abweichungen erklären & Maßnahmen hinterlegen.
+
+## 4) Formeln & Beispiele
+- **Top-down:** Zielumsatz = ∑(Segmentziel)  
+- **Bottom-up:** Umsatz = Traffic × Conversion × AOV
+
+## 5) Interpretation & Maßnahmen
+- Fokus auf **Treiberänderungen** statt reiner Abweichungszahlen.
+- Maßnahmen im Forecast mitplanen (Owner, ETA).
+
+## 6) Grenzen & Fehler
+- „Spreadsheet Illusion“: zu viele Annahmen, zu wenig Validierung.
+- Unpräzise Treiber → trügerische Genauigkeit.
+
+## 7) Checklisten
+**DoR:** [ ] Treibermodell, [ ] Datenaktualität, [ ] Versionierung  
+**DoD:** [ ] Delta-Analyse, [ ] Maßnahmen-Backlog, [ ] Kommunikation
+
+## 8) Verknüpfungen
+- Verwandt: [Zero-Based Budgeting](zero-based-budgeting.md), [Szenarioanalyse](szenario-und-sensitivitaet.md)  
+- KPIs: Forecast Accuracy, MAPE  
+- Tools: BI, Python/Excel
+
+## 9) Beispiel-Output
+```text
+Methode: Rolling Forecast
+Zeitraum: 12M rolling, Update 01.10.2025
+Ergebnis: Umsatz -6% ggü. Plan, Haupttreiber Conversion -0,3pp
+Maßnahmen: PDP-Tests priorisieren (Jamal, 20.10.), Preiserhöhung +2% (Cash, 01.11.)
+Review: 01.11.
+```

--- a/controlling/methoden/unternehmenscontrolling/szenario-und-sensitivitaet.md
+++ b/controlling/methoden/unternehmenscontrolling/szenario-und-sensitivitaet.md
@@ -1,0 +1,52 @@
+# Methode: Szenario- & Sensitivitätsanalyse
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Unsicherheiten und Treiberwirkungen transparent machen, um robuste Entscheidungen zu treffen.  
+**Typische Einsatzfälle:** Budget-/Forecast-Unsicherheit, Investitionsentscheidungen, Risikoanalysen.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Zeigt Bandbreiten möglicher Ergebnisse (Best/Expected/Worst Case).
+- Identifiziert kritische Treiber mit größtem Einfluss.
+
+## 2) Daten & Inputs
+- Baseline-Planung (P&L, Cashflow, KPIs).
+- Treiberannahmen (Preise, Mengen, Kosten, Konversionsraten).
+- Externe Faktoren (Markt, Regulierung, Wechselkurse).
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Relevante Treiber definieren und Variation festlegen.  
+2. Szenarien modellieren (z. B. Base, Optimistic, Pessimistic).  
+3. Sensitivitätsanalyse durchführen (z. B. Tornado-Diagramm, What-if).  
+4. Maßnahmen und Triggerpunkte ableiten.
+
+## 4) Formeln & Beispiele
+- **Delta-Analyse:** `ΔErgebnis = ∂Ergebnis/∂Treiber × ΔTreiber`  
+- **Beispiel:** Conversion +0,2pp → Umsatz +3%, EBIT +1,1 Mio. €.
+
+## 5) Interpretation & Maßnahmen
+- Fokus auf Treiber mit hohem Impact und hoher Unsicherheit.  
+- Frühwarnindikatoren definieren und Monitoring etablieren.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Unvollständige Treibermodelle → Scheinsicherheit.  
+- Szenarien ohne Maßnahmen → begrenzter Nutzen.
+
+## 7) Checklisten
+**DoR:** [ ] Treibermodell, [ ] Datenstand aktuell, [ ] Stakeholder abgestimmt  
+**DoD:** [ ] Szenarien dokumentiert, [ ] Maßnahmen + Trigger, [ ] Kommunikationsplan
+
+## 8) Verknüpfungen
+- Verwandt: [Rolling Forecast](rolling-forecast.md), [Investitionsrechnung](investitionsrechnung-npv-irr.md)  
+- KPIs: Forecast Accuracy, EBIT, Cashflow  
+- Tools: BI, Simulation, Python/Excel
+
+## 9) Beispiel-Output
+```text
+Methode: Szenario- & Sensitivitätsanalyse
+Zeitraum: FY 2026 Planung
+Ergebnis: Worst Case EBIT 9% vs. Base 14%; Conversion Treiber höchster Impact
+Maßnahmen: Pricing-Tests +2% (Lea, 15.11.), Kostenflex-Plan aktivieren (Jonas, 30.11.)
+Review: Monatlich
+```

--- a/controlling/methoden/unternehmenscontrolling/zero-based-budgeting.md
+++ b/controlling/methoden/unternehmenscontrolling/zero-based-budgeting.md
@@ -1,0 +1,50 @@
+# Methode: Zero-Based Budgeting (ZBB)
+
+**Kategorie:** Unternehmenscontrolling  
+**Ziel:** Budgets von Grund auf neu rechtfertigen, statt Vorjahreswerte fortzuschreiben.  
+**Typische Einsatzfälle:** Kostenrestrukturierung, Effizienzprogramme, wachstumsstarke Phasen.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Eliminierung nicht-wertschaffender Ausgaben.
+- Ressourcen gezielt auf strategische Prioritäten lenken.
+
+## 2) Daten & Inputs
+- Vollständige Kosten- und Budgetdaten je Kostenstelle.
+- Leistungskennzahlen zur Bewertung des Nutzens.
+
+## 3) Vorgehen (Schritt für Schritt)
+1. Budgetkategorien definieren und Verantwortliche zuordnen.  
+2. Jede Ausgabenposition mit Business Case und KPIs begründen lassen.  
+3. Maßnahmen/Initiativen priorisieren und Budget freigeben.  
+4. Umsetzung überwachen und Abweichungen adressieren.
+
+## 4) Formeln & Beispiele
+- Fokus auf qualitative Bewertung; ROI/Kosten-Nutzen-Relation je Maßnahme.
+
+## 5) Interpretation & Maßnahmen
+- Budgets nur bei belegtem Nutzen genehmigen.  
+- Identifizierte Einsparungen in Wachstumsinitiativen reinvestieren.
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Hoher Analyseaufwand.  
+- Gefahr von Unterinvestitionen in langfristige Themen.
+
+## 7) Checklisten
+**DoR:** [ ] Kostenstellen-Daten komplett, [ ] Verantwortliche definiert, [ ] Zielrahmen klar  
+**DoD:** [ ] Budgetbeschlüsse dokumentiert, [ ] Einsparungen nachgehalten, [ ] Review-Termine gesetzt
+
+## 8) Verknüpfungen
+- Verwandt: [Rolling Forecast](rolling-forecast.md), [Prozesskostenrechnung / ABC](prozesskostenrechnung-abc.md)  
+- KPIs: Cost-to-Income, Opex Quote  
+- Tools: ERP, BI, Workflow-Tools
+
+## 9) Beispiel-Output
+```text
+Methode: Zero-Based Budgeting
+Zeitraum: FY 2026 Planung
+Ergebnis: 12% Opex-Reduktion, 5 Mio. € in Wachstumsinitiativen reinvestiert
+Maßnahmen: Marketing-Mix-Shift (Lea, 15.11.), Outsourcing-Review (Tom, 30.11.)
+Review: Quartalsweise
+```

--- a/controlling/templates/methode-template.md
+++ b/controlling/templates/methode-template.md
@@ -1,0 +1,68 @@
+# Methode: [Titel]
+
+**Kategorie:** [Unternehmenscontrolling / E-Commerce-Controlling]  
+**Ziel:** Kurz beschreiben, welchen Management-/Steuerungszweck die Methode erfüllt.  
+**Typische Einsatzfälle:** Bulletpoints mit 2–5 Beispielen.
+
+---
+
+## 1) Zweck & Business-Nutzen
+- Was beantwortet die Methode?
+- Welche Entscheidungen werden damit besser?
+
+## 2) Daten & Inputs
+- Datenquellen (z. B. ERP, Shop, CRM, Webanalytics)
+- Mindestanforderungen an Datenqualität & -granularität
+
+## 3) Vorgehen (Schritt für Schritt)
+1. …
+2. …
+3. …
+4. …
+
+## 4) Formeln & Beispiele
+- **Formel(n):**  
+  - …
+- **Mini-Beispiel (mit Zahlen):**  
+  - Input → Rechenschritte → Output
+
+## 5) Interpretation & Maßnahmen
+- Wie lese ich das Ergebnis?
+- Typische Schwellenwerte/Benchmarks (falls sinnvoll)
+- Konkrete Handlungsoptionen
+
+## 6) Grenzen, Annahmen & typische Fehler
+- Wo kann die Methode irreführen?
+- Häufige Missverständnisse / Anti-Patterns
+
+## 7) Checklisten
+**Definition of Ready (DoR)** – bevor du startest:  
+- [ ] Datenfelder X/Y vorhanden  
+- [ ] Zeitfenster definiert  
+- [ ] Verantwortlichkeiten geklärt  
+
+**Definition of Done (DoD)** – wenn du fertig bist:  
+- [ ] Ergebnis dokumentiert (Datum, Datenstand, Version)  
+- [ ] Ableitungen & Maßnahmen festgehalten  
+- [ ] Nächster Review-Termin geplant  
+
+## 8) Verknüpfungen
+- Verwandte Methoden: …  
+- Relevante KPIs: …  
+- Tools: (z. B. dbt/SQL, Python, Looker, GA4, Excel)
+
+## 9) Beispiel-Output (Vorlage)
+```text
+Methode: [Titel]
+Zeitraum: [z. B. Q1/2025]
+Datengrundlage: [Quelle, Extraktionsdatum]
+Ergebnis (Kernaussage in 1–2 Sätzen)
+Top-3-Treiber:
+1) …
+2) …
+3) …
+Maßnahmen (Owner/ETA):
+- …
+- …
+Review: [Datum]
+```

--- a/controlling/uebersicht.md
+++ b/controlling/uebersicht.md
@@ -1,0 +1,39 @@
+# Controlling – Übersicht
+
+Dieser Bereich bündelt **zentrale Controlling-Methoden** für
+1) **Unternehmenscontrolling** (klassisch/finanziell/strategisch) und
+2) **E-Commerce-Controlling** (digital, marketing- & produktgetrieben).
+
+Jede Methode ist als Steckbrief dokumentiert:
+- Zweck & Nutzen
+- Daten & Inputs
+- Vorgehen (Schritte)
+- Formeln & Beispiele
+- Interpretation & Maßnahmen
+- Grenzen & typische Fehler
+- Checklisten (DoR / DoD)
+- Verknüpfungen
+- Beispiel-Output
+
+> Vorlage zum Ausfüllen: [`templates/methode-template.md`](templates/methode-template.md)
+
+## 📚 Methoden
+
+### Unternehmenscontrolling
+- [Balanced Scorecard](methoden/unternehmenscontrolling/balanced-scorecard.md)
+- [Deckungsbeitrag / Contribution Margin](methoden/unternehmenscontrolling/deckungsbeitrag.md)
+- [Zero-Based Budgeting (ZBB)](methoden/unternehmenscontrolling/zero-based-budgeting.md)
+- [Rolling Forecast](methoden/unternehmenscontrolling/rolling-forecast.md)
+- [Investitionsrechnung (NPV/IRR/Payback)](methoden/unternehmenscontrolling/investitionsrechnung-npv-irr.md)
+- [Working-Capital-Controlling](methoden/unternehmenscontrolling/arbeitskapital-controlling.md)
+- [Prozesskostenrechnung / ABC](methoden/unternehmenscontrolling/prozesskostenrechnung-abc.md)
+- [Szenario- & Sensitivitätsanalyse](methoden/unternehmenscontrolling/szenario-und-sensitivitaet.md)
+
+### E-Commerce-Controlling
+- [Unit Economics (LTV/CAC)](methoden/ecommerce-controlling/unit-economics-ltv-cac.md)
+- [Conversion Funnel & A/B-Testing Impact](methoden/ecommerce-controlling/conversion-funnel-und-ab-test.md)
+- [Cohort Analysis & Churn/Retention](methoden/ecommerce-controlling/cohort-analysis-und-churn.md)
+- [RFM & Basket Analysis](methoden/ecommerce-controlling/rfm-und-basket-analysis.md)
+- [Attribution Modelling](methoden/ecommerce-controlling/attribution-modelling.md)
+- [Lager & Inventory-Umschlag (Händler:innen)](methoden/ecommerce-controlling/inventur-und-umschlag-haendler.md)
+- [Marketplace-Kennzahlen (GMV, Take Rate, Net Revenue)](methoden/ecommerce-controlling/marketplace-take-rate-und-gmv.md)

--- a/uebersicht.md
+++ b/uebersicht.md
@@ -1,0 +1,33 @@
+# Übersicht – Business- & Controlling-Nachschlagewerk
+
+Dieses Repository bündelt vier Business-Säulen (**Geschäftsmodelle, Zielgruppen, Vertriebswege, Erlösmodelle**) und einen praxisnahen **Controlling-Bereich**.  
+Nutze die **Meta-Matrix** als Startpunkt und vertiefe dich dann in die Steckbriefe und Methoden.
+
+## 🚩 Schnellnavigation
+
+- Geschäftsmodelle: [`geschaeftsmodelle.md`](geschaeftsmodelle.md)
+- Zielgruppen: [`zielgruppen.md`](zielgruppen.md)
+- Vertriebswege: [`vertriebswege.md`](vertriebswege.md)
+- Erlösmodelle: [`erloesmodelle/uebersicht.md`](erloesmodelle/uebersicht.md)
+- **Controlling**: [`controlling/uebersicht.md`](controlling/uebersicht.md)
+- Meta-Matrix (Kombination aller Ebenen): [`meta-matrix.md`](meta-matrix.md)
+
+## 🔧 Wie verwenden?
+1. **Meta-Matrix** öffnen → passende Kombination identifizieren.  
+2. In den **Steckbriefen** die Details prüfen (Definition, Chancen/Risiken, Links).  
+3. Passende **Controlling-Methode** wählen (Template befüllen, Ergebnisse dokumentieren).  
+4. **Aktionen & Owner** festhalten (Definition of Done im Template).
+
+## 🧱 Struktur (Top-Level)
+```
+
+/geschaeftsmodelle.md
+/zielgruppen.md
+/vertriebswege.md
+/erloesmodelle/...
+/controlling/...
+/meta-matrix.md
+/uebersicht.md   ← diese Seite
+
+```
+```


### PR DESCRIPTION
## Summary
- add a top-level overview page that links to the new controlling knowledge base
- create controlling overview and reusable method template for consistent documentation
- document key controlling methods across corporate and e-commerce domains with examples and cross-links

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dd46b8de608329908da46b7ffaec52