### PR TITLE
Add marketing overview, templates, and method guides

### DIFF
--- a/marketing/methoden/aaarrr-funnel-pirate-metrics.md
+++ b/marketing/methoden/aaarrr-funnel-pirate-metrics.md
@@ -1,0 +1,44 @@
+# Methode: AARRR Funnel (Pirate Metrics)
+
+**Ziel:** Wachstumshebel entlang Akquisition → Aktivierung → Retention → Revenue → Referral finden.
+
+## 1) Zweck & Nutzen
+- Identifiziert Engpässe im Growth-System.
+- Priorisiert Maßnahmen mit höchstem Hebel.
+
+## 2) Inputs
+- Web/App-Analytics, CRM, Umsatzdaten
+
+## 3) Vorgehen
+1. Funnel definieren (konkrete Events/Steps).  
+2. KPI je Stufe festlegen (z. B. CR, AOV, ARPU).  
+3. Leaks & Hebel quantifizieren; Experimente planen.
+
+## 4) Metriken
+- CR je Stufe, Time-to-Value, Retention, ARPU, Referral-Rate
+
+## 5) Grenzen
+- Event-Definitionen uneinheitlich; Kanal-Bias.
+
+## 6) Checklisten
+**DoR:** [ ] Event-Taxonomie, [ ] Baseline je Stufe, [ ] Test-Backlog  
+**DoD:** [ ] Uplift gemessen, [ ] Maßnahmen live, [ ] Learnings dokumentiert
+
+## 7) Verknüpfungen
+- Controlling: Funnel & A/B → `../../controlling/methoden/ecommerce-controlling/conversion-funnel-und-ab-test.md`  
+- Erlösmodelle: `../../erloesmodelle/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Leak: Aktivierung (Signup → First Action) 27%
+Experiment: Onboarding-Checklist + Social Proof
+Ziel: +4pp Aktivierung, Payback < 3 Monate
+```
+
+---
+
+## Siehe auch
+- [Growth Loops](growth-loops.md)
+- [Landingpage-Optimierung](landingpage-optimierung.md)
+- [Attribution Models](attribution-models.md)
+- [Marketing Mix Modelling (MMM)](mmm-marketing-mix-modelling.md)

--- a/marketing/methoden/attribution-models.md
+++ b/marketing/methoden/attribution-models.md
@@ -1,0 +1,36 @@
+# Methode: Attribution Models
+
+**Ziel:** Beitrag von Kanälen/Touchpoints zur Wertschöpfung schätzen.
+
+## 1) Zweck & Nutzen
+- Budget effizient verteilen; Kanäle fair bewerten.
+
+## 2) Inputs
+- Session-/Event-Daten, UTM, Conversions, ggf. Impressionen.
+
+## 3) Vorgehen
+1. Modell wählen: Last/First/Linear/Time-Decay/Positionsbasiert/DDA.  
+2. Datenqualität sichern (Taxonomie, Identity).  
+3. Inkrementalität via Geo-/PSA-Tests prüfen.  
+4. Reporting + Handlungsregeln.
+
+## 4) Metriken
+- ROAS/CAC je Modell, Delta zu Holdout/Geo-Test.
+
+## 5) Grenzen
+- Post-View, Walled Gardens, Data Loss → Unsicherheit.
+
+## 6) Checklisten
+**DoR:** [ ] UTM sauber, [ ] Conversions stabil, [ ] Testdesign  
+**DoD:** [ ] Vergleichsreport, [ ] Budgetregeln, [ ] Review-Cadence
+
+## 7) Verknüpfungen
+- UTM: `utm-taxonomy.md`  
+- Controlling: Unit Economics, Funnel, MMM → `../../controlling/uebersicht.md`  
+- MMM: `mmm-marketing-mix-modelling.md`
+
+## 8) Beispiel-Output
+```text
+Positionsbasiert (40/20/40) statt Last Click:
+Budget-Shift +15% zu Paid Social, Gesamt-CPA –9% (4 Wochen)
+```

--- a/marketing/methoden/brand-positioning-canvas.md
+++ b/marketing/methoden/brand-positioning-canvas.md
@@ -1,0 +1,39 @@
+# Methode: Brand Positioning Canvas
+
+**Ziel:** Präzises Positionierungs-Statement samt Belegen und Tonalität entwickeln.
+
+## 1) Zweck & Nutzen
+- Differenzierung im Wettbewerb, klare Botschaft je Zielsegment.
+- Einheitliche Leitlinie für Kampagnen, Content und Produkt.
+
+## 2) Inputs
+- Markt-/Wettbewerbsanalyse, Zielgruppen-Insights, Nutzenbeweise (Proofs).
+
+## 3) Vorgehen
+1. **Für [Zielsegment]**  
+2. **Bietet [Marke/Produkt]** [Kernnutzen/Value Prop]  
+3. **Im Gegensatz zu** [Wettbewerb/Alternative]  
+4. **Weil** [Reason-to-Believe/Proofs]  
+5. **Tonalität/Voice:** [Adjektive, Stil, No-Gos]
+
+## 4) Metriken
+- Markenbekanntheit, Erinnerungswerte (Ad Recall), NPS, CTR/CR je Botschaft.
+
+## 5) Grenzen
+- Zu generisch/überladen; fehlende Proofs → unglaubwürdig.
+
+## 6) Checklisten
+**DoR:** [ ] Segment klar, [ ] Wettbewerb benannt, [ ] Proofs vorhanden  
+**DoD:** [ ] Positionierungs-Statement 1–2 Sätze, [ ] Styleguide harmonisiert
+
+## 7) Verknüpfungen
+- STP: `stp-segmentation-targeting-positioning.md`  
+- Content/SEO: `content-marketing.md`, `seo.md`  
+- Controlling: Brand-/NPS-Messung → `../../controlling/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Für „Urban Commuter“ bietet ACME Bikes stressfreie E-Mobility,
+anders als schwere Alternativen, weil ultraleicht + 60km Akku (Testsieger 2025).
+Tonalität: smart, positiv, evidenzbasiert.
+```

--- a/marketing/methoden/content-marketing.md
+++ b/marketing/methoden/content-marketing.md
@@ -1,0 +1,37 @@
+# Methode: Content Marketing
+
+**Ziel:** Nachfrage aufbauen/abholen durch relevanten, suchintensiven und teilbaren Content.
+
+## 1) Zweck & Nutzen
+- Vertrauen, organischer Traffic, niedrigere Akquisekosten.
+
+## 2) Inputs
+- Themencluster, Suchintentionen, Persona-Pains, Distribution-Plan.
+
+## 3) Vorgehen
+1. Themen-Cluster (Pillar/Cluster) & Briefings.  
+2. Produktion (Guides, Vergleiche, How-Tos, Video).  
+3. Distribution (SEO, Social, Newsletter, PR).  
+4. Repurposing (Long → Short, Slides, Snippets).  
+5. Messung & Iteration.
+
+## 4) Metriken
+- Impressions, CTR, Time-on-Page, Assisted Conversions, SQL/Revenue.
+
+## 5) Grenzen
+- Long-Game; ohne Distribution „Content-Friedhof“.
+
+## 6) Checklisten
+**DoR:** [ ] Keyword-/Intent-Map, [ ] Guidelines, [ ] Distribution-Liste  
+**DoD:** [ ] Internal Links, [ ] Tracking, [ ] Refresh-Plan
+
+## 7) Verknüpfungen
+- SEO: `seo.md`  
+- UTM/Attribution: `utm-taxonomy.md`, `attribution-models.md`  
+- Controlling: Funnel & LTV → `../../controlling/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Cluster „Projektmanagement“: 1 Pillar + 8 Cluster-Pieces
+Ziel: +25% qualifizierte Leads/Quartal; Refresh alle 6 Monate
+```

--- a/marketing/methoden/email-crm-lifecycle.md
+++ b/marketing/methoden/email-crm-lifecycle.md
@@ -1,0 +1,43 @@
+# Methode: E-Mail & CRM Lifecycle
+
+**Ziel:** Aktivierung, Bindung und Reaktivierung entlang des Lebenszyklus.
+
+## 1) Zweck & Nutzen
+- Hebt LTV, senkt Churn, verbessert Payback.
+
+## 2) Inputs
+- Events (Signup, First Purchase, Idle), Produkte, Präferenzen
+
+## 3) Vorgehen
+1. Flows aufsetzen: Welcome, Abandoned Cart, Post-Purchase, Winback.  
+2. Segmentlogiken (RFM, Interesse, Kohorten).  
+3. Content- und Angebotssystem; Frequenzsteuerung.  
+4. Messung: Uplift vs. Holdout/Control.
+
+## 4) Metriken
+- Open/Click/Conversion, Revenue per Recipient, Unsub, CLV
+
+## 5) Grenzen
+- Deliverability, Sättigung, Consent.
+
+## 6) Checklisten
+**DoR:** [ ] Events & Identities, [ ] Templates, [ ] Holdout  
+**DoD:** [ ] Flow KPIs stabil, [ ] Negative KPIs ok, [ ] Dokumentation
+
+## 7) Verknüpfungen
+- Controlling: Cohorts, LTV/CAC → `../../controlling/uebersicht.md`  
+- Erlösmodelle: Abo/Direct → `../../erloesmodelle/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Welcome-Flow: +18% First-Purchase Rate (Holdout)
+Winback 90T: +6pp Reaktivierungen, Spamrate < 0,1%
+```
+
+---
+
+## Siehe auch
+- [Marketing Automation](marketing-automation.md)
+- [Content Marketing](content-marketing.md)
+- [Attribution Models](attribution-models.md)
+- [Pricing & Promotion](pricing-und-promotion.md)

--- a/marketing/methoden/growth-loops.md
+++ b/marketing/methoden/growth-loops.md
@@ -1,0 +1,37 @@
+# Methode: Growth Loops
+
+**Ziel:** Wiederholbare Systeme, in denen Output als Input für weiteres Wachstum dient.
+
+## 1) Zweck & Nutzen
+- Nachhaltige Skalierung jenseits einmaliger Kampagnen.
+- Planbare Acquisition/Engagement über Loops (Content, Referral, Paid, UGC).
+
+## 2) Inputs
+- Kanal-/Produkt-Mechaniken, Cost/Revenue-Relationen, Tracking der Loop-Schritte.
+
+## 3) Vorgehen
+1. **Loop skizzieren:** Input → Action → Output → Reinvestment.  
+2. Messpunkte/Guardrails definieren.  
+3. Engpässe identifizieren, Experimente priorisieren.  
+4. Reinvest-Logik (Budget/Features) festlegen.
+
+## 4) Metriken
+- Loop-Cycle-Time, K-Faktor/Referral-Rate, CPA→LTV, Content-to-Signup-Rate.
+
+## 5) Grenzen
+- Abhängigkeit von Plattformregeln; Saturation-Effekte.
+
+## 6) Checklisten
+**DoR:** [ ] Loop-Karte, [ ] Messpunkte, [ ] Hypothesen  
+**DoD:** [ ] Bottleneck verbessert, [ ] Reinvest-Regeln aktiv
+
+## 7) Verknüpfungen
+- AARRR: `aaarrr-funnel-pirate-metrics.md`  
+- Attribution/MMM: `attribution-models.md`, `mmm-marketing-mix-modelling.md`  
+- Controlling: LTV/CAC → `../../controlling/methoden/ecommerce-controlling/unit-economics-ltv-cac.md`
+
+## 8) Beispiel-Output
+```text
+Content-Loop: Blog → SEO-Traffic → Lead-Magnet → Email Nurture → Signup
+Bottleneck: Lead→Signup 14% → Ziel 20% (LP-Test + Incentive)
+```

--- a/marketing/methoden/landingpage-optimierung.md
+++ b/marketing/methoden/landingpage-optimierung.md
@@ -1,0 +1,35 @@
+# Methode: Landingpage-Optimierung
+
+**Ziel:** Relevanz, Klarheit und Überzeugungskraft von LPs erhöhen.
+
+## 1) Zweck & Nutzen
+- Höhere CR/AOV, schnellere Payback-Periode.
+
+## 2) Inputs
+- Message Hierarchy, Value Prop, Social Proof, UX-Heuristiken.
+
+## 3) Vorgehen
+1. Diagnose (Scrollmaps, Heuristik, User-Feedback).  
+2. Hypothesen & Priorisierung (ICE/PIE).  
+3. Varianten bauen (Copy, Visuals, Layout).  
+4. Testen & ausrollen.
+
+## 4) Metriken
+- CR, RPV, Bounce/Scroll Depth, Speed, Form-Abbruch.
+
+## 5) Grenzen
+- Local Maxima; Kanal-/Segment-Unterschiede.
+
+## 6) Checklisten
+**DoR:** [ ] Tracking okay, [ ] Hypothesen, [ ] Design/Dev-Slot  
+**DoD:** [ ] Stat. Signifikanz, [ ] Learnings dokumentiert
+
+## 7) Verknüpfungen
+- Funnel & A/B: `aaarrr-funnel-pirate-metrics.md`, `../../controlling/methoden/ecommerce-controlling/conversion-funnel-und-ab-test.md`  
+- UTM/Attribution: `utm-taxonomy.md`, `attribution-models.md`
+
+## 8) Beispiel-Output
+```text
+Variante B (Value Prop über Falz + Trust-Badges): +9,1% CR
+Rollout: 100%, Follow-up: Pricing-Block testen
+```

--- a/marketing/methoden/marketing-automation.md
+++ b/marketing/methoden/marketing-automation.md
@@ -1,0 +1,36 @@
+# Methode: Marketing Automation
+
+**Ziel:** Skalierte, personalisierte Journeys entlang des Customer Lifecycle.
+
+## 1) Zweck & Nutzen
+- Höhere Relevanz, bessere Retention, effizientere Teams.
+
+## 2) Inputs
+- Events (Signups, Käufe, Engagement), Profile, Scoring.
+
+## 3) Vorgehen
+1. Trigger/Events & Data Contracts definieren.  
+2. Journeys modellieren (Onboarding, Cross-/Upsell, Winback).  
+3. Branching/Scoring, Throttling & Guardrails.  
+4. QA/Monitoring, Holdouts, Iteration.
+
+## 4) Metriken
+- Flow-Umsatz, Lift vs. Holdout, Time-to-Value, Churn-Impact.
+
+## 5) Grenzen
+- Datenqualität, Consent/Deliverability, Over-Automation.
+
+## 6) Checklisten
+**DoR:** [ ] Event-Spez, [ ] Templates, [ ] Holdout-Design  
+**DoD:** [ ] Monitoring Dashboards, [ ] Iterationsplan
+
+## 7) Verknüpfungen
+- E-Mail/CRM: `email-crm-lifecycle.md`  
+- UTM/Attribution: `utm-taxonomy.md`, `attribution-models.md`  
+- Controlling: Cohorts/Churn → `../../controlling/methoden/ecommerce-controlling/cohort-analysis-und-churn.md`
+
+## 8) Beispiel-Output
+```text
+Journey „First 30 Days“: 6 Steps, Lift +11% First-Purchase (Holdout)
+Next: Branch für High-Value-Segment
+```

--- a/marketing/methoden/mmm-marketing-mix-modelling.md
+++ b/marketing/methoden/mmm-marketing-mix-modelling.md
@@ -1,0 +1,34 @@
+# Methode: Marketing Mix Modelling (MMM)
+
+**Ziel:** Ökonometrisches Modell quantifiziert Kanaleffekte inkl. Offline, Saisonalität & Carryover.
+
+## 1) Zweck & Nutzen
+- Budgetallokation auf Gesamtwirkung, weniger Tracking-Bias.
+
+## 2) Inputs
+- Zeitreihen: Sales/Leads, Kanalspend, Preise, Promo, Saisonalität, externe Faktoren (Wetter, Konkurrenz).
+
+## 3) Vorgehen
+1. Datenaufbereitung (Lag/Carryover/Saturation).  
+2. Modellierung (z. B. Bayes/Robust Regression).  
+3. Validierung (Holdout, Posterior Predictive Checks).  
+4. Response Curves & Budgetoptimierung.
+
+## 4) Metriken
+- MAPE/R², ROI je Kanal, Diminishing Returns.
+
+## 5) Grenzen
+- Aggregatniveau; Modellannahmen kritisch prüfen.
+
+## 6) Checklisten
+**DoR:** [ ] Vollständige Zeitreihen, [ ] Feature-Eng, [ ] Validierungsplan  
+**DoD:** [ ] Response-Kurven, [ ] Budget-Plan, [ ] Monitoring
+
+## 7) Verknüpfungen
+- Attribution & UTM: `attribution-models.md`, `utm-taxonomy.md`  
+- Controlling: Forecast & Szenarien → `../../controlling/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Optimierungs-Vorschlag: +20% TV, –15% SEA, +10% Social → erwarteter Umsatz +6% bei gleichem Budget
+```

--- a/marketing/methoden/pricing-und-promotion.md
+++ b/marketing/methoden/pricing-und-promotion.md
@@ -1,0 +1,35 @@
+# Methode: Pricing & Promotion
+
+**Ziel:** Preisstrategie und Angebotsmechaniken zur Umsatz- und Margensteuerung.
+
+## 1) Zweck & Nutzen
+- Balance aus Absatz, Marge, Markenwirkung, Wettbewerb.
+
+## 2) Inputs
+- Preiselastizität, Kostenstruktur, Konkurrenzpreise, Saisonalität.
+
+## 3) Vorgehen
+1. Strategie wählen (Skimming, Penetration, Value-Based).  
+2. Preistests (Geo/A/B), Bundles, Coupons, Staffelpreise.  
+3. Guardrails (Mindestmargen, MAP), Governance.  
+4. Review & Automatisierung (Rules/Engines).
+
+## 4) Metriken
+- Marge, DB, Price Index, Promo-Umsatzanteil, Lift vs. Holdout.
+
+## 5) Grenzen
+- „Promo-Erziehung“, Kannibalisierung, Kanal-Konflikte.
+
+## 6) Checklisten
+**DoR:** [ ] Kosten & DB-Logik, [ ] Benchmark, [ ] Testdesign  
+**DoD:** [ ] Effekt gemessen (Inkrementalität), [ ] Guardrails eingehalten
+
+## 7) Verknüpfungen
+- Controlling: DB, NPV/IRR, Szenarien → `../../controlling/uebersicht.md`  
+- Vertrieb/Modelle: `../../vertriebswege.md`, `../../erloesmodelle/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Bundle „Starter+Pro“: +12% ARPU, Marge stabil
+MAP-Regel für Reseller eingeführt, Price Index 0,98
+```

--- a/marketing/methoden/sea-paid-search.md
+++ b/marketing/methoden/sea-paid-search.md
@@ -1,0 +1,43 @@
+# Methode: SEA / Paid Search
+
+**Ziel:** Intent-basierten Traffic einkaufen und rentabel skalieren.
+
+## 1) Zweck & Nutzen
+- Planbar skalierbar bei positiver Unit Economics.
+
+## 2) Inputs
+- Keyword/Query-Listen, Gebotsstrategie, Anzeigentexte, LPs
+
+## 3) Vorgehen
+1. Kampagnenstruktur (Brand/Non-Brand/Competitor).  
+2. Match-Types & Negatives, Gebotslogik.  
+3. Creative/LP-Tests.  
+4. Budgetsteuerung nach **LTV/CAC** bzw. **ROAS**.
+
+## 4) Metriken
+- CPC, CTR, QS, CVR, CPA/CAC, ROAS, Payback
+
+## 5) Grenzen
+- Auktionsdynamik, Saisonalität, Attribution-Bias.
+
+## 6) Checklisten
+**DoR:** [ ] UTM, [ ] Conversions/Events, [ ] Bidding-Guardrails  
+**DoD:** [ ] Stat. signifikante Tests, [ ] Query-Mining, [ ] Maßnahmenlog
+
+## 7) Verknüpfungen
+- Controlling: Unit Economics, Attribution → `../../controlling/uebersicht.md`  
+- Landingpage: `landingpage-optimierung.md`
+
+## 8) Beispiel-Output
+```text
+Non-Brand Exact: CPA 38 €, Ziel 45 € → skalieren +20%
+DSA: CPA 62 € → pausieren; LP-Relevanz erhöhen
+```
+
+---
+
+## Siehe auch
+- [Landingpage-Optimierung](landingpage-optimierung.md)
+- [UTM-Taxonomy & Governance](utm-taxonomy.md)
+- [Attribution Models](attribution-models.md)
+- [Pricing & Promotion](pricing-und-promotion.md)

--- a/marketing/methoden/seo.md
+++ b/marketing/methoden/seo.md
@@ -1,0 +1,45 @@
+# Methode: SEO (Search Engine Optimization)
+
+**Ziel:** Organische Sichtbarkeit erhöhen, qualifizierten Traffic und Umsatz steigern.
+
+## 1) Zweck & Nutzen
+- Nachhaltige, margenstarke Demand-Capture-Quelle.
+
+## 2) Inputs
+- Keyword-Research, Tech-Audits, Content-Inventar, Backlink-Profile
+
+## 3) Vorgehen
+1. **Technik:** Crawlability, Core Web Vitals, Indexierung.  
+2. **Content:** Suchintention, Infostruktur, E-E-A-T.  
+3. **Authority:** Interne Verlinkung, Backlinks.  
+4. **Messung:** Rankings, CTR, SEO-Umsatz/Leads.
+
+## 4) Metriken
+- Sichtbarkeitsindex, Impressions/CTR, CR SEO, Umsatz/Lead aus SEO
+
+## 5) Grenzen
+- Lange Wirkungskette; Abhängigkeit von Updates.
+
+## 6) Checklisten
+**DoR:** [ ] Keyword-Map, [ ] Tech-Backlog, [ ] Content-Plan  
+**DoD:** [ ] Pages live, [ ] Interne Links, [ ] Tracking & Report
+
+## 7) Verknüpfungen
+- Vertriebswege: Onlineshop/Content → `../../vertriebswege.md`  
+- Controlling: Attribution/MMM → `../../controlling/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Cluster „Laufschuhe Damen“: 12 Seiten, CWV ok
+Ziel: +30% SEO-Umsatz in 6 Monaten
+Maßnahmen: 8 Kategorieseiten verbessern, 4 Guides, interne Verlinkung
+```
+
+---
+
+## Siehe auch
+- [Content Marketing](content-marketing.md)
+- [Landingpage-Optimierung](landingpage-optimierung.md)
+- [UTM-Taxonomy & Governance](utm-taxonomy.md)
+- [Attribution Models](attribution-models.md)
+- [Marketing Mix Modelling (MMM)](mmm-marketing-mix-modelling.md)

--- a/marketing/methoden/social-ads.md
+++ b/marketing/methoden/social-ads.md
@@ -1,0 +1,44 @@
+# Methode: Social Ads (Paid Social)
+
+**Ziel:** Nachfrage aufbauen (Discovery) und konvertieren (DR).
+
+## 1) Zweck & Nutzen
+- Reichweite, Zielgruppen-Fit, Creative-getriebene Skalierung.
+
+## 2) Inputs
+- Audiences, Creatives, Formate (Video/Image), Landingpages
+
+## 3) Vorgehen
+1. Struktur: Prospecting vs. Retargeting.  
+2. Creative-Testing (Hooks, CTAs, Formate).  
+3. Budget- & Lernphasen-Management.  
+4. Messung: Post-Click/-View, Geo-Tests/MMM.
+
+## 4) Metriken
+- CPM, CTR, CPC, CVR, CPA/CAC, LTV/CAC, Incrementality
+
+## 5) Grenzen
+- Signalverlust (Tracking), Creative-Fatigue.
+
+## 6) Checklisten
+**DoR:** [ ] Creative-Backlog, [ ] Pixel/Events, [ ] UTM-Setup  
+**DoD:** [ ] Gewinner-Creatives skaliert, [ ] Frequency unter Kontrolle
+
+## 7) Verknüpfungen
+- Controlling: Cohorts/Attribution/MMM → `../../controlling/uebersicht.md`  
+- Templates: `../templates/experiment-template.md`
+
+## 8) Beispiel-Output
+```text
+Hook-Variante B: +42% CVR, CPA 31 € (–18% ggü. Control)
+Skalierung auf 1.5x Budget; Rotation nach 10 Tagen
+```
+
+---
+
+## Siehe auch
+- [Content Marketing](content-marketing.md)
+- [Growth Loops](growth-loops.md)
+- [UTM-Taxonomy & Governance](utm-taxonomy.md)
+- [Attribution Models](attribution-models.md)
+- [Landingpage-Optimierung](landingpage-optimierung.md)

--- a/marketing/methoden/stp-segmentation-targeting-positioning.md
+++ b/marketing/methoden/stp-segmentation-targeting-positioning.md
@@ -1,0 +1,46 @@
+# Methode: STP – Segmentation, Targeting, Positioning
+
+**Ziel:** Märkte segmentieren, attraktive Zielsegmente auswählen und differenziert positionieren.
+
+## 1) Zweck & Nutzen
+- Fokus auf Segmente mit größtem Potenzial/LTV.
+- Klare, differenzierende Botschaft je Segment.
+
+## 2) Daten & Inputs
+- Demografie, Verhalten, Bedürfnisse, Kaufanlässe
+- Kundendaten (CRM/Shop/Analytics), Marktstudien
+
+## 3) Vorgehen
+1. **Segmentation:** Cluster bilden (Bedarf/Verhalten/Wert).  
+2. **Targeting:** Segmente bewerten (Größe, Erreichbarkeit, Profit).  
+3. **Positioning:** Nutzenversprechen + Belege + Tonalität je Segment.
+
+## 4) Metriken
+- Segmentgröße, Penetration, LTV/CAC, Conversion
+
+## 5) Grenzen
+- Overfitting / zu viele Segmente; fehlende Datenqualität.
+
+## 6) Checklisten
+**DoR:** [ ] Daten-Exploration, [ ] Segment-Kriterien, [ ] Messbare KPIs  
+**DoD:** [ ] Zielsegmente gewählt, [ ] Positionierung pro Segment, [ ] Testplan
+
+## 7) Verknüpfungen
+- Zielgruppen: `../../zielgruppen.md` (Repo-Wurzel)  
+- Vertriebswege: `../../vertriebswege.md`  
+- Controlling: Cohorten, LTV/CAC → `../../controlling/methoden/ecommerce-controlling/unit-economics-ltv-cac.md`
+
+## 8) Beispiel-Output
+```text
+Segmente: „Sparfüchse“, „Qualitätskäufer:innen“, „Early Adopter“
+Target: Early Adopter (DE/AT), CAC-Deckel 45 €, gewünschter LTV/CAC ≥ 3
+Positionierung: „Schneller zur neuesten Technik – ohne Komplexität.“
+```
+
+---
+
+## Siehe auch
+- [Brand Positioning Canvas](brand-positioning-canvas.md)
+- [Content Marketing](content-marketing.md)
+- [Pricing & Promotion](pricing-und-promotion.md)
+- [Growth Loops](growth-loops.md)

--- a/marketing/methoden/utm-taxonomy.md
+++ b/marketing/methoden/utm-taxonomy.md
@@ -1,0 +1,36 @@
+# Methode: UTM-Taxonomy & Governance
+
+**Ziel:** Einheitliche Kampagnen-Kennzeichnung für sauberes Tracking & Attribution.
+
+## 1) Zweck & Nutzen
+- Verlässliche Reports (Kanal/Quelle/Kampagne/Content).
+- Schnellere Analysen, weniger „unknown“.
+
+## 2) Inputs
+- Namenskonventionen, Kanalliste, Kampagnenplan, QA-Prozess.
+
+## 3) Vorgehen
+1. Konventionen definieren: `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`.  
+2. Generator/Sheet bereitstellen, QA-Checks.  
+3. Monitoring (404/Redirects, Param-Verlust).  
+4. Schulung & Review.
+
+## 4) Metriken
+- Anteil korrekt getaggter Sessions/Revenue, „unknown“-Quote.
+
+## 5) Grenzen
+- Manuelle Fehler; Plattformen entfernen Parameter.
+
+## 6) Checklisten
+**DoR:** [ ] Konvention Draft, [ ] Tool/Sheet, [ ] Owner  
+**DoD:** [ ] Doku live, [ ] QA aktiv, [ ] Training erfolgt
+
+## 7) Verknüpfungen
+- Attribution/MMM: `attribution-models.md`, `mmm-marketing-mix-modelling.md`  
+- Controlling: Reports & KPIs → `../../controlling/uebersicht.md`
+
+## 8) Beispiel-Output
+```text
+Standard: utm_source=meta, utm_medium=paid_social, utm_campaign=fy25_q4_launch_x
+QA: daily Check, Unknown < 3%
+```

--- a/marketing/templates/campaign-brief-template.md
+++ b/marketing/templates/campaign-brief-template.md
@@ -1,0 +1,54 @@
+# Campaign Brief – Template
+
+**Kampagne:** [Name]  
+**Ziel(e):** [Primary KPI + ggf. Secondary]  
+**Zeitraum:** [Start–End]  
+**Budget:** [Betrag, Währung]  
+**Geschäftsmodell / Angebot:** [B2C/B2B/… + Produkt/USP]  
+**Zielgruppe:** [Segment/Persona]  
+**Vertriebsweg:** [Onlineshop/Leadgen/…]  
+**Erlösmodell:** [Direktverkauf/Abo/…]
+
+---
+
+## 1) Kontext & Problemstatement
+- Ausgangslage, Anlass, Saisonalität, Wettbewerb
+
+## 2) Ziel & KPI-Definition
+- Primär-KPI (z. B. **Revenue**, **Leads MQL**, **CAC**, **ROAS**)
+- Sekundär (AOV, CR, LTV/CAC, Payback)
+
+## 3) Targeting & Botschaft
+- Segment(e) / Persona(s)
+- Value Proposition, Key Message, Proof Points
+
+## 4) Kanäle & Taktik
+- Kanal-Mix (SEO/SEA/Paid Social/CRM/…)
+- Formate/Assets (Creatives, LPs)
+- Geo/Device/Placements
+
+## 5) Messung & Setup
+- Tracking (UTM-Konvention, Events, Conversions)
+- Attribution (z. B. DDA, Positionsbasiert)
+- Dashboards/Reports
+
+## 6) Planung
+- Zeitplan (Flighting), Budget Allokation, Cap
+- Meilensteine, Abnahmen
+
+## 7) Risiken & Annahmen
+- Creatives, Inventar, Saisonalität, technische Limiter
+
+## 8) Experimente
+- Hypothesen + ICE-Priorisierung
+- Testdesign (Dauer, Power, Metrik)
+
+## 9) Verantwortlichkeiten
+- Owner, Stakeholder, Freigaben
+
+## 10) Definition of Done
+- [ ] Ziele gemessen & dokumentiert
+- [ ] Learnings & Maßnahmen fixiert
+- [ ] Assets/Setups versioniert
+
+**Anhänge:** Audience-Definition, Creative-Spez, LP-Wireframe, Media-Plan

--- a/marketing/templates/experiment-template.md
+++ b/marketing/templates/experiment-template.md
@@ -1,0 +1,22 @@
+# Experiment – Template
+
+**Hypothese:** Wenn wir [Änderung], dann [Erwartung], weil [Begründung].  
+**Metrik:** [Primary], **Guardrails:** [z. B. CR Checkout, CPA]  
+**Segment:** [Zielgruppe/Kanal/Device]  
+**Dauer/Power:** [n, α, β]  
+**Owner:** [Name]
+
+## Setup
+- Variante(n), Traffic-Split, Randomisierung, Ausschlüsse
+
+## Erfolgskriterien
+- Abbruchkriterien, Mindestlaufzeit, Mindest-Effektgröße
+
+## Ergebnisse
+- Messwerte, Konfidenz, Effekt (Absolut/Relativ), Nebenwirkungen
+
+## Interpretation
+- Was bedeuten die Resultate? Grenzen/Confounder?
+
+## Nächste Schritte
+- Rollout / Re-Test / Iteration

--- a/marketing/uebersicht.md
+++ b/marketing/uebersicht.md
@@ -1,0 +1,38 @@
+# Marketing – Übersicht
+
+Dieses Kapitel bündelt **Strategie, Kanäle und Messung** für wachstumsorientiertes Marketing.  
+Jede Methode folgt einem einheitlichen Steckbrief (Zweck, Inputs, Vorgehen, Metriken, Grenzen, Checklisten, Verknüpfungen).
+
+## Schnellnavigation
+
+### Strategie & Grundlagen
+- [STP – Segmentation, Targeting, Positioning](methoden/stp-segmentation-targeting-positioning.md)
+- [Brand Positioning Canvas](methoden/brand-positioning-canvas.md)
+- [AARRR Funnel (Pirate Metrics)](methoden/aaarrr-funnel-pirate-metrics.md)
+- [Growth Loops](methoden/growth-loops.md)
+- [Pricing & Promotion](methoden/pricing-und-promotion.md)
+
+### Kanäle & Taktiken
+- [SEO](methoden/seo.md)
+- [SEA / Paid Search](methoden/sea-paid-search.md)
+- [Social Ads (Paid Social)](methoden/social-ads.md)
+- [Content Marketing](methoden/content-marketing.md)
+- [E-Mail & CRM Lifecycle](methoden/email-crm-lifecycle.md)
+- [Marketing Automation](methoden/marketing-automation.md)
+- [Landingpage-Optimierung](methoden/landingpage-optimierung.md)
+- [UTM-Taxonomy](methoden/utm-taxonomy.md)
+
+### Messung & Wirkung
+- [Attribution Models](methoden/attribution-models.md)
+- [Marketing Mix Modelling (MMM)](methoden/mmm-marketing-mix-modelling.md)
+
+## Templates
+- Kampagnen-Briefing: [`templates/campaign-brief-template.md`](templates/campaign-brief-template.md)  
+- Experiment-Dokument: [`templates/experiment-template.md`](templates/experiment-template.md)
+
+## Verknüpfungen
+- Geschäftsmodelle: `../geschaeftsmodelle.md`  
+- Zielgruppen: `../zielgruppen.md`  
+- Vertriebswege: `../vertriebswege.md`  
+- Erlösmodelle: `../erloesmodelle/uebersicht.md`  
+- Controlling (KPIs, Tests, Attribution, MMM): `../controlling/uebersicht.md`


### PR DESCRIPTION
## Summary
- add a marketing overview page linking strategy, channel, and measurement resources
- introduce campaign brief and experiment templates for reusable execution docs
- document key marketing methods covering strategy frameworks, channels, and analytics

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dd49a652008329b8b95fae3bd245d3