### PR TITLE
Add Blame76 AdminShareLinks Magento 2 module scaffold under magento-admin-share

### DIFF
--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/Block/Adminhtml/Generator.php
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/Block/Adminhtml/Generator.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Blame76\AdminShareLinks\Block\Adminhtml;
+
+use Blame76\AdminShareLinks\Model\TargetResolver;
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+
+class Generator extends Template
+{
+    protected $_template = 'Blame76_AdminShareLinks::generator.phtml';
+
+    public function __construct(
+        Context $context,
+        private readonly TargetResolver $targetResolver,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSupportedTypes(): array
+    {
+        return $this->targetResolver->getSupportedTypes();
+    }
+
+    public function getShareBaseUrl(): string
+    {
+        return $this->getUrl('blame76share/link/go', ['_current' => false]);
+    }
+
+    public function getExampleUrl(): string
+    {
+        return $this->getUrl('blame76share/link/go', [
+            '_current' => false,
+            'type' => 'product',
+            'id' => 123
+        ]);
+    }
+
+    public function escapeJsQuote(string $value): string
+    {
+        return str_replace("'", "\\'", $value);
+    }
+}

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/Controller/Adminhtml/Index/Index.php
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/Controller/Adminhtml/Index/Index.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Blame76\AdminShareLinks\Controller\Adminhtml\Index;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Index extends Action
+{
+    public const ADMIN_RESOURCE = 'Blame76_AdminShareLinks::generator';
+
+    public function __construct(
+        Context $context,
+        private readonly PageFactory $pageFactory
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Page
+    {
+        $page = $this->pageFactory->create();
+        $page->setActiveMenu('Blame76_AdminShareLinks::generator');
+        $page->getConfig()->getTitle()->prepend(__('Admin Share Links'));
+
+        return $page;
+    }
+}

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/Controller/Adminhtml/Link/Go.php
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/Controller/Adminhtml/Link/Go.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Blame76\AdminShareLinks\Controller\Adminhtml\Link;
+
+use Blame76\AdminShareLinks\Model\TargetResolver;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class Go extends Action
+{
+    public const ADMIN_RESOURCE = 'Blame76_AdminShareLinks::redirect';
+
+    public function __construct(
+        Context $context,
+        private readonly TargetResolver $targetResolver,
+        private readonly RedirectFactory $redirectFactory,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Redirect
+    {
+        $resultRedirect = $this->redirectFactory->create();
+
+        try {
+            $type = (string)$this->getRequest()->getParam('type');
+            $id = (int)$this->getRequest()->getParam('id');
+
+            $target = $this->targetResolver->resolve($type, $id);
+
+            if (!$this->_authorization->isAllowed($target['acl'])) {
+                $this->messageManager->addErrorMessage(
+                    __('You are not allowed to open this target.')
+                );
+
+                return $resultRedirect->setPath('admin/dashboard/index');
+            }
+
+            return $resultRedirect->setPath(
+                $target['route'],
+                $target['params']
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                'Admin share link failed.',
+                [
+                    'message' => $e->getMessage(),
+                    'request_params' => $this->getSafeRequestParams($this->getRequest())
+                ]
+            );
+
+            $this->messageManager->addErrorMessage(
+                __('The share link is invalid or could not be resolved.')
+            );
+
+            return $resultRedirect->setPath('blame76share/index/index');
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSafeRequestParams(RequestInterface $request): array
+    {
+        $params = $request->getParams();
+
+        unset($params['key'], $params['form_key']);
+
+        return $params;
+    }
+}

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/Model/TargetResolver.php
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/Model/TargetResolver.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Blame76\AdminShareLinks\Model;
+
+use InvalidArgumentException;
+
+class TargetResolver
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function resolve(string $type, int $entityId): array
+    {
+        $type = strtolower(trim($type));
+
+        if ($entityId <= 0) {
+            throw new InvalidArgumentException('Invalid entity ID.');
+        }
+
+        $map = [
+            'product' => [
+                'route' => 'catalog/product/edit',
+                'params' => ['id' => $entityId],
+                'acl' => 'Magento_Catalog::products',
+                'label' => 'Product'
+            ],
+            'customer' => [
+                'route' => 'customer/index/edit',
+                'params' => ['id' => $entityId],
+                'acl' => 'Magento_Customer::manage',
+                'label' => 'Customer'
+            ],
+            'order' => [
+                'route' => 'sales/order/view',
+                'params' => ['order_id' => $entityId],
+                'acl' => 'Magento_Sales::sales_order',
+                'label' => 'Order'
+            ],
+        ];
+
+        if (!isset($map[$type])) {
+            throw new InvalidArgumentException(sprintf('Unsupported target type "%s".', $type));
+        }
+
+        return $map[$type];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSupportedTypes(): array
+    {
+        return [
+            'product' => 'Product',
+            'customer' => 'Customer',
+            'order' => 'Order',
+        ];
+    }
+}

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/composer.json
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "blame76/magento2-admin-share-links",
+    "description": "Magento 2 admin share links with persistent redirect entry points.",
+    "type": "magento2-module",
+    "license": [
+        "proprietary"
+    ],
+    "require": {
+        "php": "^8.1 || ^8.2",
+        "magento/framework": "*",
+        "magento/module-backend": "*",
+        "magento/module-catalog": "*",
+        "magento/module-customer": "*",
+        "magento/module-sales": "*"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Blame76\\AdminShareLinks\\": ""
+        }
+    }
+}

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/acl.xml
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/acl.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- Beispielcode – nicht produktiv einsetzen. -->
+<acl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <resources>
+        <resource id="Magento_Backend::admin">
+            <resource id="Blame76_AdminShareLinks::root" title="Admin Share Links" sortOrder="999">
+                <resource id="Blame76_AdminShareLinks::generator" title="Generator" sortOrder="10"/>
+                <resource id="Blame76_AdminShareLinks::redirect" title="Redirect Endpoint" sortOrder="20"/>
+            </resource>
+        </resource>
+    </resources>
+</acl>

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/adminhtml/menu.xml
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/adminhtml/menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- Beispielcode – nicht produktiv einsetzen. -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add id="Blame76_AdminShareLinks::generator"
+             title="Admin Share Links"
+             module="Blame76_AdminShareLinks"
+             sortOrder="999"
+             parent="Magento_Backend::system"
+             action="blame76share/index/index"
+             resource="Blame76_AdminShareLinks::generator"/>
+    </menu>
+</config>

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/adminhtml/routes.xml
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/adminhtml/routes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!-- Beispielcode – nicht produktiv einsetzen. -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="blame76share" frontName="blame76share">
+            <module name="Blame76_AdminShareLinks" before="Magento_Backend"/>
+        </route>
+    </router>
+</config>

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/module.xml
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/etc/module.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!-- Beispielcode – nicht produktiv einsetzen. -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Blame76_AdminShareLinks"/>
+</config>

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/registration.php
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/registration.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Blame76_AdminShareLinks',
+    __DIR__
+);

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/view/adminhtml/layout/blame76share_index_index.xml
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/view/adminhtml/layout/blame76share_index_index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Beispielcode – nicht produktiv einsetzen. -->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Blame76\AdminShareLinks\Block\Adminhtml\Generator"
+                   name="blame76.admin.share.generator"
+                   template="Blame76_AdminShareLinks::generator.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/magento-admin-share/app/code/Blame76/AdminShareLinks/view/adminhtml/templates/generator.phtml
+++ b/magento-admin-share/app/code/Blame76/AdminShareLinks/view/adminhtml/templates/generator.phtml
@@ -1,0 +1,134 @@
+<?php
+/**
+ * @var \Blame76\AdminShareLinks\Block\Adminhtml\Generator $block
+ */
+$types = $block->getSupportedTypes();
+$shareBaseUrl = $block->getShareBaseUrl();
+?>
+<div class="admin__page-section">
+    <div class="admin__page-section-title">
+        <span class="title"><?= $block->escapeHtml(__('Persistent Admin Share Links')) ?></span>
+    </div>
+
+    <div class="admin__page-section-content">
+        <p>
+            <?= $block->escapeHtml(__('Generate stable backend links for supported entity types.')) ?>
+        </p>
+        <p>
+            <?= $block->escapeHtml(__('These links intentionally avoid reusing foreign session-specific parameters such as secret keys or form keys.')) ?>
+        </p>
+
+        <div class="admin__field field">
+            <label class="admin__field-label" for="blame76-share-type">
+                <span><?= $block->escapeHtml(__('Target Type')) ?></span>
+            </label>
+            <div class="admin__field-control">
+                <select id="blame76-share-type" class="admin__control-select">
+                    <?php foreach ($types as $typeCode => $typeLabel): ?>
+                        <option value="<?= $block->escapeHtmlAttr($typeCode) ?>">
+                            <?= $block->escapeHtml($typeLabel) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
+
+        <div class="admin__field field">
+            <label class="admin__field-label" for="blame76-share-id">
+                <span><?= $block->escapeHtml(__('Entity ID')) ?></span>
+            </label>
+            <div class="admin__field-control">
+                <input type="number"
+                       min="1"
+                       id="blame76-share-id"
+                       class="admin__control-text"
+                       placeholder="123" />
+            </div>
+        </div>
+
+        <div class="admin__field field">
+            <label class="admin__field-label" for="blame76-share-url">
+                <span><?= $block->escapeHtml(__('Generated Share URL')) ?></span>
+            </label>
+            <div class="admin__field-control">
+                <input type="text"
+                       id="blame76-share-url"
+                       class="admin__control-text"
+                       readonly="readonly"
+                       value="<?= $block->escapeHtmlAttr($block->getExampleUrl()) ?>" />
+            </div>
+        </div>
+
+        <div class="admin__page-section-item-actions">
+            <button type="button" class="action-default scalable" id="blame76-generate-url">
+                <span><?= $block->escapeHtml(__('Generate URL')) ?></span>
+            </button>
+
+            <button type="button" class="action-primary scalable" id="blame76-copy-url">
+                <span><?= $block->escapeHtml(__('Copy URL')) ?></span>
+            </button>
+
+            <a href="<?= $block->escapeUrl($block->getExampleUrl()) ?>"
+               target="_blank"
+               class="action-secondary scalable"
+               id="blame76-open-url">
+                <span><?= $block->escapeHtml(__('Open URL')) ?></span>
+            </a>
+        </div>
+
+        <hr style="margin: 20px 0;">
+
+        <div class="message message-notice">
+            <div>
+                <strong><?= $block->escapeHtml(__('Example:')) ?></strong>
+                <code><?= $block->escapeHtml($block->getExampleUrl()) ?></code>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+require(['jquery'], function ($) {
+    'use strict';
+
+    var baseUrl = '<?= $block->escapeJsQuote($shareBaseUrl) ?>';
+
+    function buildUrl() {
+        var type = $('#blame76-share-type').val();
+        var id = $('#blame76-share-id').val();
+
+        if (!id || parseInt(id, 10) <= 0) {
+            return '';
+        }
+
+        return baseUrl + 'type/' + encodeURIComponent(type) + '/id/' + encodeURIComponent(id) + '/';
+    }
+
+    function refresh() {
+        var url = buildUrl();
+        $('#blame76-share-url').val(url);
+        $('#blame76-open-url').attr('href', url || '#');
+    }
+
+    $('#blame76-generate-url').on('click', refresh);
+    $('#blame76-share-type, #blame76-share-id').on('change keyup', refresh);
+
+    $('#blame76-copy-url').on('click', function () {
+        var $input = $('#blame76-share-url');
+        var value = $input.val();
+
+        if (!value) {
+            alert('Please generate a valid URL first.');
+            return;
+        }
+
+        $input.trigger('focus').trigger('select');
+
+        try {
+            document.execCommand('copy');
+        } catch (e) {
+            console.warn('Copy failed', e);
+        }
+    });
+});
+</script>


### PR DESCRIPTION
### Motivation
- Provide a copy-paste-ready Magento 2 adminhtml module that offers stable, persistent admin share links for backend entities. 
- Keep implementation isolated in the requested subfolder `magento-admin-share` and avoid session-specific parameters like secret keys or form keys. 
- Offer a simple generator UI in the backend so admins can create and copy stable share URLs for common target types.

### Description
- Add a full module scaffold under `magento-admin-share/app/code/Blame76/AdminShareLinks` including `composer.json`, `registration.php`, and `etc/module.xml`.
- Implement admin integration with `etc/adminhtml/routes.xml`, `etc/acl.xml`, and `etc/adminhtml/menu.xml` and a backend generator page at `blame76share/index/index`.
- Add redirect logic with `Model/TargetResolver.php` (maps `product`, `customer`, `order` to safe target routes) and controller `Controller/Adminhtml/Link/Go.php` which performs ACL checks and redirects via `ResultRedirect`.
- Add backend generator block/layout/template with `Block/Adminhtml/Generator.php`, `view/adminhtml/layout/blame76share_index_index.xml`, and `view/adminhtml/templates/generator.phtml` including client-side URL building and copy helper.

### Testing
- Ran PHP lint (`php -l`) on all added PHP files and there were no syntax errors. 
- Verified file tree with `find magento-admin-share -type f` to ensure the scaffold was created as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc95f9db48329810d7873975b14b4)